### PR TITLE
Skeleton for first analyzer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,45 @@
+version: '{build}'
+branches:
+  only:
+  - master
+  - /^v\d+(?:\.\d+)?$/
+  - /[\b_]validate\b/
+skip_tags: true
+skip_commits:
+  files:
+    - doc/*
+    - '**/*.md'
+    - .vsts-ci.yml
+nuget:
+  disable_publish_on_pr: true
+image: Visual Studio 2017
+configuration: Release
+environment:
+  VisualStudioVersion: 15.0
+  TreatWarningsAsErrors: true
+  CodeAnalysisTreatWarningsAsErrors: true
+before_build:
+- |- # Restore TWICE. See https://github.com/AArnott/Nerdbank.GitVersioning/issues/113#issuecomment-285903085
+  msbuild src\Microsoft.VisualStudio.SDK.Analyzers.sln /nologo /m /v:quiet /t:restore
+  msbuild src\Microsoft.VisualStudio.SDK.Analyzers.sln /nologo /m /v:quiet /t:restore > nul
+build_script:
+- msbuild src\Microsoft.VisualStudio.SDK.Analyzers.sln /nologo /m /bl /v:minimal /t:build,pack
+test_script:
+- >-
+    SET testdir=bin\Microsoft.VisualStudio.SDK.Analyzers.Tests\%configuration%\net46
+
+    "%xunit20%\xunit.console.x86.exe"
+    "%testdir%\Microsoft.VisualStudio.SDK.Analyzers.Tests.dll"
+    -noshadow
+    -html "%testdir%\testresults.html" -xml "%testdir%\testresults.xml"
+    -appveyor
+    -notrait "TestCategory=FailsInCloudTest"
+    -nologo
+
+artifacts:
+- path: bin\**\*.nupkg
+  name: NuGet Package
+- path: msbuild.binlog
+  name: Build log
+- path: bin\**\testresults*
+  name: Test results

--- a/doc/VSSDK001.md
+++ b/doc/VSSDK001.md
@@ -1,0 +1,2 @@
+# VSSDK001 Derive from AsyncPackage
+

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,62 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+# Make Visual Studio consistent with SA1101 (use "this" prefix), but allow StyleCop to report it
+dotnet_style_qualification_for_field = true:silent
+dotnet_style_qualification_for_property = true:silent
+dotnet_style_qualification_for_method = true:silent
+dotnet_style_qualification_for_event = true:silent
+
+# Make Visual Studio consistent with SA1121 (use predefined type), but allow StyleCop to report it
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+csharp_style_var_for_built_in_types = false:silent
+
+# Additional settings to make the Visual Studio formatter follow StyleCop
+dotnet_sort_system_directives_first = true
+
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_within_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
+
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <MicroBuildVersion>2.0.53</MicroBuildVersion>
+    <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Avoid using MSBuild properties as macros for PackageReference/@Version
+         due to issue https://github.com/dotnet/project-system/issues/2129 -->
+    <PackageReference Include="GitLink" Version="3.2.0-unstable0018" PrivateAssets="all" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.53" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.17" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
+  </ItemGroup>
+
+  <!-- Workaround https://github.com/AArnott/Nerdbank.GitVersioning/issues/113#issuecomment-285903085 -->
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' == 'true' ">
+    <Import Project="$(UserProfile)\.nuget\packages\nerdbank.gitversioning\1.6.35\buildCrossTargeting\Nerdbank.GitVersioning.targets"
+            Condition="Exists('$(UserProfile)\.nuget\packages\nerdbank.gitversioning\1.6.35\buildCrossTargeting\Nerdbank.GitVersioning.targets')" />
+  </ImportGroup>
+  <Target Name="FixUpVersion"
+      BeforeTargets="_GenerateRestoreProjectSpec"
+      DependsOnTargets="GetBuildVersion"
+      Condition=" '$(NerdbankGitVersioningTasksPath)' != '' " />
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,13 @@
+<Project>
+  <!--
+    These properties must be in the targets file because the .NET SDK is erroneously stomping
+    them for some of the DEF assemblies due to this work-around: https://github.com/Microsoft/vstest/pull/528
+  -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <CodeAnalysisRuleSet>Microsoft.VisualStudio.SDK.Analyzers.Tests.ruleset</CodeAnalysisRuleSet>
+
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MicroBuild.NonShipping" Version="2.0.53" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.VisualStudio.SDK.Analyzers\Microsoft.VisualStudio.SDK.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.ruleset
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.ruleset
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+    <Rule Id="CA1049" Action="Warning" />
+    <Rule Id="CA1060" Action="Warning" />
+    <Rule Id="CA1061" Action="Warning" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1065" Action="Warning" />
+    <Rule Id="CA1301" Action="Warning" />
+    <Rule Id="CA1400" Action="Warning" />
+    <Rule Id="CA1401" Action="Warning" />
+    <Rule Id="CA1403" Action="Warning" />
+    <Rule Id="CA1404" Action="Warning" />
+    <Rule Id="CA1405" Action="Warning" />
+    <Rule Id="CA1410" Action="Warning" />
+    <Rule Id="CA1415" Action="Warning" />
+    <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1900" Action="Warning" />
+    <Rule Id="CA1901" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2100" Action="Warning" />
+    <Rule Id="CA2101" Action="Warning" />
+    <Rule Id="CA2108" Action="Warning" />
+    <Rule Id="CA2111" Action="Warning" />
+    <Rule Id="CA2112" Action="Warning" />
+    <Rule Id="CA2114" Action="Warning" />
+    <Rule Id="CA2116" Action="Warning" />
+    <Rule Id="CA2117" Action="Warning" />
+    <Rule Id="CA2122" Action="Warning" />
+    <Rule Id="CA2123" Action="Warning" />
+    <Rule Id="CA2124" Action="Warning" />
+    <Rule Id="CA2126" Action="Warning" />
+    <Rule Id="CA2131" Action="Warning" />
+    <Rule Id="CA2132" Action="Warning" />
+    <Rule Id="CA2133" Action="Warning" />
+    <Rule Id="CA2134" Action="Warning" />
+    <Rule Id="CA2137" Action="Warning" />
+    <Rule Id="CA2138" Action="Warning" />
+    <Rule Id="CA2140" Action="Warning" />
+    <Rule Id="CA2141" Action="Warning" />
+    <Rule Id="CA2146" Action="Warning" />
+    <Rule Id="CA2147" Action="Warning" />
+    <Rule Id="CA2149" Action="Warning" />
+    <Rule Id="CA2200" Action="Warning" />
+    <Rule Id="CA2202" Action="Warning" />
+    <Rule Id="CA2207" Action="Warning" />
+    <Rule Id="CA2212" Action="Warning" />
+    <Rule Id="CA2213" Action="Warning" />
+    <Rule Id="CA2214" Action="Warning" />
+    <Rule Id="CA2216" Action="Warning" />
+    <Rule Id="CA2220" Action="Warning" />
+    <Rule Id="CA2229" Action="Warning" />
+    <Rule Id="CA2231" Action="Warning" />
+    <Rule Id="CA2232" Action="Warning" />
+    <Rule Id="CA2235" Action="Warning" />
+    <Rule Id="CA2236" Action="Warning" />
+    <Rule Id="CA2237" Action="Warning" />
+    <Rule Id="CA2238" Action="Warning" />
+    <Rule Id="CA2240" Action="Warning" />
+    <Rule Id="CA2241" Action="Warning" />
+    <Rule Id="CA2242" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1600" Action="Hidden" />
+    <Rule Id="SA1601" Action="Hidden" />
+    <Rule Id="SA1602" Action="Hidden" />
+  </Rules>
+</RuleSet>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
+{
+    using System;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class VSSDK001DeriveFromAsyncPackageTests
+    {
+        public VSSDK001DeriveFromAsyncPackageTests(ITestOutputHelper logger)
+        {
+        }
+
+        [Fact]
+        public void FirstTest()
+        {
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.sln
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27407.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.SDK.Analyzers", "Microsoft.VisualStudio.SDK.Analyzers\Microsoft.VisualStudio.SDK.Analyzers.csproj", "{C01185FA-A307-4EE5-8DB4-7BE702B16E77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.SDK.Analyzers.Tests", "Microsoft.VisualStudio.SDK.Analyzers.Tests\Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj", "{91513758-87A5-43C2-8383-0CEC8B5A3C27}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C01185FA-A307-4EE5-8DB4-7BE702B16E77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C01185FA-A307-4EE5-8DB4-7BE702B16E77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C01185FA-A307-4EE5-8DB4-7BE702B16E77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C01185FA-A307-4EE5-8DB4-7BE702B16E77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91513758-87A5-43C2-8383-0CEC8B5A3C27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91513758-87A5-43C2-8383-0CEC8B5A3C27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91513758-87A5-43C2-8383-0CEC8B5A3C27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91513758-87A5-43C2-8383-0CEC8B5A3C27}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B26EDBEE-6240-419F-9E6C-55AC2F09ADA0}
+	EndGlobalSection
+EndGlobal

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+
+    <PackageTags>analyzers visualstudio vssdk sdk</PackageTags>
+    <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.4.27004" PrivateAssets="all" />
+  </ItemGroup>
+  
+</Project>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+
+    /// <summary>
+    /// Internal utilities for use by analyzers.
+    /// </summary>
+    internal static class Utils
+    {
+        /// <summary>
+        /// Gets the help link to use for each analyzer.
+        /// </summary>
+        /// <param name="analyzerId">The <see cref="DiagnosticDescriptor.Id"/> for the diagnostic to get help on.</param>
+        /// <returns>The absolute URL with documentation on the specified analyzer.</returns>
+        internal static string GetHelpLink(string analyzerId)
+        {
+            return $"https://github.com/Microsoft/VSSDK-Analyzers/blob/master/doc/{analyzerId}.md";
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackage.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackage.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.Shell;
+
+    /// <summary>
+    /// Discovers VS packages that derive directly from <see cref="Package"/> instead of <see cref="AsyncPackage"/>.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class VSSDK001DeriveFromAsyncPackage : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+        /// </summary>
+        public const string Id = "VSSDK001";
+
+        /// <summary>
+        /// A reusable descriptor for diagnostics produced by this analyzer.
+        /// </summary>
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: "Derive your VS package from AsyncPackage",
+            messageFormat: "Your Package-derived class should derive from AsyncPackage instead.",
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+        }
+    }
+}

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositorypath" value="packages" />
+  </config>
+  <packageSources>
+    <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="vs-devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "xmlHeader": false,
+      "companyName": "Microsoft Corporation"
+    }
+  }
+}

--- a/src/version.json
+++ b/src/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "15.6-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
This adds:

1. the first analyzer class (empty)
1. the first analyzer test class (empty)
1. .editorconfig
1. the build authoring to support [building in appveyor](https://ci.appveyor.com/project/AArnott/vssdk-analyzers) and signing in MicroBuild. @madskristensen  after completing this PR can you add an AppVeyor definition to validate PRs?

Coming in a future PR (or adding to this one):
1. VSTS YML build definition
1. A bunch of helper code for analyzer tests
1. A real analyzer with real tests.