### PR TITLE
Depend on threading analyzers

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.4.27004" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.5.32" PrivateAssets="none" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
This way, customers who want the VS SDK analyzers automatically get the threading analyzers too.