### PR TITLE
Add code fix for VSSDK001

### DIFF
--- a/doc/VSSDK001.md
+++ b/doc/VSSDK001.md
@@ -33,3 +33,5 @@ class MyCoolPackage : AsyncPackage {
     }
 }
 ```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/CodeFixVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/CodeFixVerifier.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Formatting;
+    using Microsoft.CodeAnalysis.Simplification;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public abstract class CodeFixVerifier : DiagnosticVerifier
+    {
+        protected CodeFixVerifier(ITestOutputHelper logger)
+        : base(logger)
+        {
+        }
+
+        /// <summary>
+        /// Returns the codefix being tested (C#) - to be implemented in non-abstract class
+        /// </summary>
+        /// <returns>The CodeFixProvider to be used for CSharp code</returns>
+        protected abstract CodeFixProvider GetCSharpCodeFixProvider();
+
+        /// <summary>
+        /// Called to test a C# codefix when applied on the inputted string as a source
+        /// </summary>
+        /// <param name="oldSource">A class in the form of a string before the CodeFix was applied to it</param>
+        /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
+        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+        /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
+        protected void VerifyCSharpFix(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
+        {
+            this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, hasEntrypoint);
+        }
+
+        /// <summary>
+        /// Called to test a C# codefix when applied on the inputted string as a source
+        /// </summary>
+        /// <param name="oldSources">Code files, each in the form of a string before the CodeFix was applied to it</param>
+        /// <param name="newSources">Code files, each in the form of a string after the CodeFix was applied to it</param>
+        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
+        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+        /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
+        protected void VerifyCSharpFix(string[] oldSources, string[] newSources, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, bool hasEntrypoint = false)
+        {
+            this.VerifyFix(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, hasEntrypoint);
+        }
+
+        protected void VerifyNoCSharpFixOffered(string oldSource, bool hasEntrypoint = false)
+        {
+            this.VerifyNoFixOffered(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzer(), this.GetCSharpCodeFixProvider(), oldSource, hasEntrypoint);
+        }
+
+        /// <summary>
+        /// Get the existing compiler diagnostics on the inputted document.
+        /// </summary>
+        /// <param name="document">The Document to run the compiler diagnostic analyzers on</param>
+        /// <returns>The compiler diagnostics that were found in the code</returns>
+        private static IEnumerable<Diagnostic> GetCompilerDiagnostics(Document document)
+        {
+            return document.GetSemanticModelAsync().Result.GetDiagnostics();
+        }
+
+        /// <summary>
+        /// Compare two collections of Diagnostics, and return a list of any new diagnostics that appear only in the second collection.
+        /// Note: Considers Diagnostics to be the same if they have the same Ids.  In the case of multiple diagnostics with the same Id in a row,
+        /// this method may not necessarily return the new one.
+        /// </summary>
+        /// <param name="diagnostics">The Diagnostics that existed in the code before the CodeFix was applied</param>
+        /// <param name="newDiagnostics">The Diagnostics that exist in the code after the CodeFix was applied</param>
+        /// <returns>A list of Diagnostics that only surfaced in the code after the CodeFix was applied</returns>
+        private static IEnumerable<Diagnostic> GetNewDiagnostics(IEnumerable<Diagnostic> diagnostics, IEnumerable<Diagnostic> newDiagnostics)
+        {
+            var oldArray = diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+            var newArray = newDiagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+
+            int oldIndex = 0;
+            int newIndex = 0;
+
+            while (newIndex < newArray.Length)
+            {
+                if (oldIndex < oldArray.Length && oldArray[oldIndex].Id == newArray[newIndex].Id)
+                {
+                    ++oldIndex;
+                    ++newIndex;
+                }
+                else
+                {
+                    yield return newArray[newIndex++];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Given a Document, turn it into a string based on the syntax root
+        /// </summary>
+        /// <param name="document">The Document to be converted to a string</param>
+        /// <returns>A string containing the syntax of the Document after formatting</returns>
+        private static string GetStringFromDocument(Document document)
+        {
+            var simplifiedDoc = Simplifier.ReduceAsync(document, Simplifier.Annotation).Result;
+            var root = simplifiedDoc.GetSyntaxRootAsync().Result;
+            root = Formatter.Format(root, Formatter.Annotation, simplifiedDoc.Project.Solution.Workspace);
+            return root.GetText().ToString();
+        }
+
+        /// <summary>
+        /// Apply the inputted CodeAction to the inputted document.
+        /// Meant to be used to apply codefixes.
+        /// </summary>
+        /// <param name="document">The Document to apply the fix on</param>
+        /// <param name="codeAction">A CodeAction that will be applied to the Document.</param>
+        /// <returns>A Document with the changes from the CodeAction</returns>
+        private static Document ApplyFix(Document document, CodeAction codeAction)
+        {
+            var operations = codeAction.GetOperationsAsync(CancellationToken.None).GetAwaiter().GetResult();
+            var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+            return solution.GetDocument(document.Id);
+        }
+
+        private void VerifyNoFixOffered(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string source, bool hasEntrypoint)
+        {
+            var document = CreateDocument(source, language, hasEntrypoint);
+            var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(ImmutableArray.Create(analyzer), new[] { document });
+            var compilerDiagnostics = GetCompilerDiagnostics(document);
+            var attempts = analyzerDiagnostics.Length;
+
+            for (int i = 0; i < attempts; ++i)
+            {
+                var actions = new List<CodeAction>();
+                var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), CancellationToken.None);
+                codeFixProvider.RegisterCodeFixesAsync(context).Wait();
+                Assert.Empty(actions);
+            }
+        }
+
+        /// <summary>
+        /// General verifier for codefixes.
+        /// Creates a Document from the source string, then gets diagnostics on it and applies the relevant codefixes.
+        /// Then gets the string after the codefix is applied and compares it with the expected result.
+        /// Note: If any codefix causes new diagnostics to show up, the test fails unless allowNewCompilerDiagnostics is set to true.
+        /// </summary>
+        /// <param name="language">The language the source code is in</param>
+        /// <param name="analyzer">The analyzer to be applied to the source code</param>
+        /// <param name="codeFixProvider">The codefix to be applied to the code wherever the relevant Diagnostic is found</param>
+        /// <param name="oldSources">Code files, each in the form of a string before the CodeFix was applied to it</param>
+        /// <param name="newSources">Code files, each in the form of a string after the CodeFix was applied to it</param>
+        /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple in the same location</param>
+        /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
+        /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
+        private void VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string[] oldSources, string[] newSources, int? codeFixIndex, bool allowNewCompilerDiagnostics, bool hasEntrypoint)
+        {
+            var project = CreateProject(oldSources, language, hasEntrypoint);
+            var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(ImmutableArray.Create(analyzer), project.Documents.ToArray(), hasEntrypoint);
+            var compilerDiagnostics = project.Documents.SelectMany(doc => GetCompilerDiagnostics(doc));
+            var attempts = analyzerDiagnostics.Length;
+
+            // We'll go through enough for each diagnostic to be caught once
+            for (int i = 0; i < attempts; ++i)
+            {
+                var diagnostic = analyzerDiagnostics[0]; // just get the first one -- the list gets smaller with each loop.
+                var document = project.GetDocument(diagnostic.Location.SourceTree);
+                var actions = new List<CodeAction>();
+                var context = new CodeFixContext(document, diagnostic, (a, d) => actions.Add(a), CancellationToken.None);
+                codeFixProvider.RegisterCodeFixesAsync(context).Wait();
+                if (!actions.Any())
+                {
+                    continue;
+                }
+
+                document = ApplyFix(document, actions[codeFixIndex ?? 0]);
+                project = document.Project;
+
+                this.Logger.WriteLine("Code after fix:\n{0}", document.GetSyntaxRootAsync().Result.ToFullString());
+
+                analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(ImmutableArray.Create(analyzer), project.Documents.ToArray());
+                var newCompilerDiagnostics = GetNewDiagnostics(
+                    compilerDiagnostics,
+                    project.Documents.SelectMany(doc => GetCompilerDiagnostics(doc)));
+
+                // Check if applying the code fix introduced any new compiler diagnostics
+                if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
+                {
+                    // Format and get the compiler diagnostics again so that the locations make sense in the output
+                    document = document.WithSyntaxRoot(Formatter.Format(document.GetSyntaxRootAsync().Result, Formatter.Annotation, document.Project.Solution.Workspace));
+                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
+
+                    Assert.True(
+                        false,
+                        string.Format(
+                            "Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
+                            string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
+                            document.GetSyntaxRootAsync().Result.ToFullString()));
+                }
+            }
+
+            // After applying all of the code fixes, compare the resulting string to the inputted one
+            int j = 0;
+            foreach (var document in project.Documents)
+            {
+                var actual = GetStringFromDocument(document);
+                Assert.Equal(newSources[j++], actual, ignoreLineEndingDifferences: true);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -30,6 +30,8 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
         {
             Path.Combine("Microsoft.VisualStudio.Shell.Interop", "7.10.6071", "lib", "Microsoft.VisualStudio.Shell.Interop.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.15.0", "15.4.27004", "lib", "Microsoft.VisualStudio.Shell.15.0.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Framework", "15.4.27004", "lib\\net45", "Microsoft.VisualStudio.Shell.Framework.dll"),
+            Path.Combine("Microsoft.VisualStudio.Threading", "15.4.4", "lib\\net45", "Microsoft.VisualStudio.Threading.dll"),
         });
 
         private static string csharpDefaultFileExt = "cs";

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -190,6 +190,18 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
         }
 
         /// <summary>
+        /// Create a Document from a string through creating a project that contains it.
+        /// </summary>
+        /// <param name="source">Classes in the form of a string</param>
+        /// <param name="language">The language the source code is in</param>
+        /// <param name="hasEntrypoint"><c>true</c> to set the compiler in a mode as if it were compiling an exe (as opposed to a dll).</param>
+        /// <returns>A Document created from the source string</returns>
+        protected static Document CreateDocument(string source, string language = LanguageNames.CSharp, bool hasEntrypoint = false)
+        {
+            return CreateProject(new[] { source }, language, hasEntrypoint).Documents.First();
+        }
+
+        /// <summary>
         /// Get the CSharp analyzer being tested - to be implemented in non-abstract class
         /// </summary>
         protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.ruleset
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.ruleset
@@ -74,4 +74,7 @@
     <Rule Id="SA1602" Action="Hidden" />
     <Rule Id="SA1615" Action="Hidden" />
   </Rules>
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="AvoidAsyncSuffix" Action="Hidden" />
+  </Rules>
 </RuleSet>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageAnalyzerTests.cs
@@ -8,16 +8,16 @@ using Microsoft.VisualStudio.SDK.Analyzers.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
-public class VSSDK001DeriveFromAsyncPackageTests : DiagnosticVerifier
+public class VSSDK001DeriveFromAsyncPackageAnalyzerTests : DiagnosticVerifier
 {
     private DiagnosticResult expect = new DiagnosticResult
     {
-        Id = VSSDK001DeriveFromAsyncPackage.Id,
+        Id = VSSDK001DeriveFromAsyncPackageAnalyzer.Id,
         SkipVerifyMessage = true,
         Severity = DiagnosticSeverity.Info,
     };
 
-    public VSSDK001DeriveFromAsyncPackageTests(ITestOutputHelper logger)
+    public VSSDK001DeriveFromAsyncPackageAnalyzerTests(ITestOutputHelper logger)
         : base(logger)
     {
     }
@@ -65,5 +65,5 @@ class Test : Package, IDisposable {
         this.VerifyCSharpDiagnostic(test, this.expect);
     }
 
-    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK001DeriveFromAsyncPackage();
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK001DeriveFromAsyncPackageAnalyzer();
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -36,6 +36,34 @@ class Test : AsyncPackage
     }
 
     [Fact]
+    public void BaseTypeChangesToAsyncPackage_WithInterfaces()
+    {
+        var test = @"
+using System;
+using Microsoft.VisualStudio.Shell;
+
+class Test : Package, IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+";
+        var withFix = @"
+using System;
+using Microsoft.VisualStudio.Shell;
+
+class Test : AsyncPackage, IDisposable
+{
+    public void Dispose()
+    {
+    }
+}
+";
+        this.VerifyCSharpFix(test, withFix);
+    }
+
+    [Fact]
     public void BaseTypeChangesToAsyncPackage_NoUsings()
     {
         var test = @"
@@ -67,6 +95,47 @@ namespace Microsoft.VisualStudio
 {
     class Test : Shell.AsyncPackage
     {
+    }
+}
+";
+        this.VerifyCSharpFix(test, withFix);
+    }
+
+    [Fact]
+    public void InitializeOverrideIsUpdated()
+    {
+        var test = @"
+using System;
+
+class Test : Microsoft.VisualStudio.Shell.Package
+{
+    protected override void Initialize()
+    {
+        Console.WriteLine(""before"");
+
+        base.Initialize(); // base invocation
+
+        Console.WriteLine(""after"");
+    }
+}
+";
+        var withFix = @"
+using System;
+
+class Test : Microsoft.VisualStudio.Shell.AsyncPackage
+{
+    protected override async System.Threading.Tasks.Task InitializeAsync(System.Threading.CancellationToken cancellationToken, IProgress<Microsoft.VisualStudio.Shell.ServiceProgressData> progress)
+    {
+        Console.WriteLine(""before"");
+
+        await base.InitializeAsync(cancellationToken, progress); // base invocation
+
+        // When initialized asynchronously, we *may* be on a background thread at this point.
+        // Do any initialization that requires the UI thread after switching to the UI thread.
+        // Otherwise, remove the switch to the UI thread if you don't need it.
+        await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        Console.WriteLine(""after"");
     }
 }
 ";

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.SDK.Analyzers;
+using Microsoft.VisualStudio.SDK.Analyzers.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+public class VSSDK001DeriveFromAsyncPackageCodeFixTests : CodeFixVerifier
+{
+    public VSSDK001DeriveFromAsyncPackageCodeFixTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void BaseTypeChangesToAsyncPackage()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test : Package
+{
+}
+";
+        var withFix = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test : AsyncPackage
+{
+}
+";
+        this.VerifyCSharpFix(test, withFix);
+    }
+
+    [Fact]
+    public void BaseTypeChangesToAsyncPackage_NoUsings()
+    {
+        var test = @"
+class Test : Microsoft.VisualStudio.Shell.Package
+{
+}
+";
+        var withFix = @"
+class Test : Microsoft.VisualStudio.Shell.AsyncPackage
+{
+}
+";
+        this.VerifyCSharpFix(test, withFix);
+    }
+
+    [Fact]
+    public void BaseTypeChangesToAsyncPackage_InPartiallyMatchingNamespace()
+    {
+        var test = @"
+namespace Microsoft.VisualStudio
+{
+    class Test : Microsoft.VisualStudio.Shell.Package
+    {
+    }
+}
+";
+        var withFix = @"
+namespace Microsoft.VisualStudio
+{
+    class Test : Shell.AsyncPackage
+    {
+    }
+}
+";
+        this.VerifyCSharpFix(test, withFix);
+    }
+
+    protected override CodeFixProvider GetCSharpCodeFixProvider() => new VSSDK001DeriveFromAsyncPackageCodeFix();
+
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK001DeriveFromAsyncPackageAnalyzer();
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <CodeAnalysisRuleSet>Microsoft.VisualStudio.SDK.Analyzers.ruleset</CodeAnalysisRuleSet>
 
     <PackageTags>analyzers visualstudio vssdk sdk</PackageTags>
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=746387</PackageReleaseNotes>
     <Description>A collection of analyzers to help Visual Studio extension developers write quality code.</Description>
-
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.4.27004" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.5.32" PrivateAssets="none" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="none" />
   </ItemGroup>
   
 </Project>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.ruleset
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.ruleset
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+    <Rule Id="CA1049" Action="Warning" />
+    <Rule Id="CA1060" Action="Warning" />
+    <Rule Id="CA1061" Action="Warning" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1065" Action="Warning" />
+    <Rule Id="CA1301" Action="Warning" />
+    <Rule Id="CA1400" Action="Warning" />
+    <Rule Id="CA1401" Action="Warning" />
+    <Rule Id="CA1403" Action="Warning" />
+    <Rule Id="CA1404" Action="Warning" />
+    <Rule Id="CA1405" Action="Warning" />
+    <Rule Id="CA1410" Action="Warning" />
+    <Rule Id="CA1415" Action="Warning" />
+    <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1900" Action="Warning" />
+    <Rule Id="CA1901" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2100" Action="Warning" />
+    <Rule Id="CA2101" Action="Warning" />
+    <Rule Id="CA2108" Action="Warning" />
+    <Rule Id="CA2111" Action="Warning" />
+    <Rule Id="CA2112" Action="Warning" />
+    <Rule Id="CA2114" Action="Warning" />
+    <Rule Id="CA2116" Action="Warning" />
+    <Rule Id="CA2117" Action="Warning" />
+    <Rule Id="CA2122" Action="Warning" />
+    <Rule Id="CA2123" Action="Warning" />
+    <Rule Id="CA2124" Action="Warning" />
+    <Rule Id="CA2126" Action="Warning" />
+    <Rule Id="CA2131" Action="Warning" />
+    <Rule Id="CA2132" Action="Warning" />
+    <Rule Id="CA2133" Action="Warning" />
+    <Rule Id="CA2134" Action="Warning" />
+    <Rule Id="CA2137" Action="Warning" />
+    <Rule Id="CA2138" Action="Warning" />
+    <Rule Id="CA2140" Action="Warning" />
+    <Rule Id="CA2141" Action="Warning" />
+    <Rule Id="CA2146" Action="Warning" />
+    <Rule Id="CA2147" Action="Warning" />
+    <Rule Id="CA2149" Action="Warning" />
+    <Rule Id="CA2200" Action="Warning" />
+    <Rule Id="CA2202" Action="Warning" />
+    <Rule Id="CA2207" Action="Warning" />
+    <Rule Id="CA2212" Action="Warning" />
+    <Rule Id="CA2213" Action="Warning" />
+    <Rule Id="CA2214" Action="Warning" />
+    <Rule Id="CA2216" Action="Warning" />
+    <Rule Id="CA2220" Action="Warning" />
+    <Rule Id="CA2229" Action="Warning" />
+    <Rule Id="CA2231" Action="Warning" />
+    <Rule Id="CA2232" Action="Warning" />
+    <Rule Id="CA2235" Action="Warning" />
+    <Rule Id="CA2236" Action="Warning" />
+    <Rule Id="CA2237" Action="Warning" />
+    <Rule Id="CA2238" Action="Warning" />
+    <Rule Id="CA2240" Action="Warning" />
+    <Rule Id="CA2241" Action="Warning" />
+    <Rule Id="CA2242" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="UseConfigureAwait" Action="Warning" />
+  </Rules>
+</RuleSet>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
@@ -18,5 +18,32 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             nameof(VisualStudio),
             nameof(Shell),
         };
+
+        /// <summary>
+        /// Gets an array for each element in the namespace System.
+        /// </summary>
+        internal static readonly IReadOnlyList<string> System = new[]
+        {
+            nameof(System),
+        };
+
+        /// <summary>
+        /// Gets an array for each element in the namespace System.Threading.
+        /// </summary>
+        internal static readonly IReadOnlyList<string> SystemThreading = new[]
+        {
+            nameof(System),
+            nameof(global::System.Threading),
+        };
+
+        /// <summary>
+        /// Gets an array for each element in the namespace System.Threading.Tasks.
+        /// </summary>
+        internal static readonly IReadOnlyList<string> SystemThreadingTasks = new[]
+        {
+            nameof(System),
+            nameof(global::System.Threading),
+            nameof(global::System.Threading.Tasks),
+        };
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Gets arrays that describe various popular namespaces.
+    /// </summary>
+    internal static class Namespaces
+    {
+        /// <summary>
+        /// Gets an array for each element in the namespace Microsoft.VisualStudio.Shell.
+        /// </summary>
+        internal static readonly IReadOnlyList<string> MicrosoftVisualStudioShell = new[]
+        {
+            nameof(Microsoft),
+            nameof(VisualStudio),
+            nameof(Shell),
+        };
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Gets magic strings that describe types and their members.
+    /// </summary>
+    internal static class Types
+    {
+        /// <summary>
+        /// Describes the <see cref="Shell.AsyncPackage"/> type.
+        /// </summary>
+        internal static class AsyncPackage
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.AsyncPackage"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.AsyncPackage);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -3,6 +3,8 @@
 namespace Microsoft.VisualStudio.SDK.Analyzers
 {
     using System.Collections.Generic;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     /// <summary>
     /// Gets magic strings that describe types and their members.
@@ -20,9 +22,152 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             internal const string TypeName = nameof(Shell.AsyncPackage);
 
             /// <summary>
+            /// The name of the Initialize method.
+            /// </summary>
+            internal const string Initialize = "Initialize";
+
+            /// <summary>
+            /// The name of the InitializeAsync method.
+            /// </summary>
+            internal const string InitializeAsync = "InitializeAsync";
+
+            /// <summary>
             /// Gets an array of the nesting namespaces for this type.
             /// </summary>
             internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+        }
+
+        /// <summary>
+        /// Describes the <see cref="System.Threading.CancellationToken"/> type.
+        /// </summary>
+        internal static class CancellationToken
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="System.Threading.CancellationToken"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(System.Threading.CancellationToken);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemThreading;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+        }
+
+        /// <summary>
+        /// Describes the <see cref="System.Threading.Tasks.Task"/> type.
+        /// </summary>
+        internal static class Task
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="System.Threading.Tasks.Task"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(System.Threading.Tasks.Task);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemThreadingTasks;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.ThreadHelper"/> type.
+        /// </summary>
+        internal static class ThreadHelper
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.ThreadHelper"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.ThreadHelper);
+
+            /// <summary>
+            /// The name of the <see cref="Shell.ThreadHelper.JoinableTaskFactory"/> property.
+            /// </summary>
+            internal const string JoinableTaskFactory = nameof(Shell.ThreadHelper.JoinableTaskFactory);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Threading.JoinableTaskFactory"/> type.
+        /// </summary>
+        internal static class JoinableTaskFactory
+        {
+            /// <summary>
+            /// The name of the <see cref="JoinableTaskFactory.SwitchToMainThreadAsync"/> method.
+            /// </summary>
+            internal const string SwitchToMainThreadAsync = nameof(JoinableTaskFactory.SwitchToMainThreadAsync);
+        }
+
+        /// <summary>
+        /// Describes the <see cref="System.IProgress{T}"/> type.
+        /// </summary>
+        internal static class IProgress
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="System.IProgress{T}"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(System.IProgress<int>);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.System;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            /// <param name="typeArgument">The type argument for the <see cref="System.IProgress{T}"/> type.</param>
+            /// <returns>The type syntax.</returns>
+            internal static TypeSyntax TypeSyntaxOf(TypeSyntax typeArgument)
+            {
+                return Utils.QualifyName(
+                    Namespace,
+                    SyntaxFactory.GenericName(TypeName).AddTypeArgumentListArguments(typeArgument));
+            }
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.ServiceProgressData"/> type.
+        /// </summary>
+        internal static class ServiceProgressData
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.ServiceProgressData"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.ServiceProgressData);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
@@ -3,8 +3,11 @@
 namespace Microsoft.VisualStudio.SDK.Analyzers
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
@@ -93,6 +96,39 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Produces the syntax necessary to qualify a simple name.
+        /// </summary>
+        /// <param name="qualifiers">The qualifiers (e.g. the namespace that qualifies a type).</param>
+        /// <param name="simpleName">The simple type name.</param>
+        /// <returns>The qualified type name.</returns>
+        internal static NameSyntax QualifyName(IReadOnlyList<string> qualifiers, SimpleNameSyntax simpleName)
+        {
+            if (qualifiers == null)
+            {
+                throw new ArgumentNullException(nameof(qualifiers));
+            }
+
+            if (simpleName == null)
+            {
+                throw new ArgumentNullException(nameof(simpleName));
+            }
+
+            if (qualifiers.Count == 0)
+            {
+                throw new ArgumentException("At least one qualifier required.");
+            }
+
+            NameSyntax result = SyntaxFactory.IdentifierName(qualifiers[0]);
+            for (int i = 1; i < qualifiers.Count; i++)
+            {
+                var rightSide = SyntaxFactory.IdentifierName(qualifiers[i]);
+                result = SyntaxFactory.QualifiedName(result, rightSide);
+            }
+
+            return SyntaxFactory.QualifiedName(result, simpleName);
         }
 
         private static bool LaunchDebuggerExceptionFilter()

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
 
             if (qualifiers.Count == 0)
             {
-                throw new ArgumentException("At least one qualifier required.");
+                throw new ArgumentException("At least one qualifier required.", nameof(qualifiers));
             }
 
             NameSyntax result = SyntaxFactory.IdentifierName(qualifiers[0]);

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Simplification;
 
     /// <summary>
     /// Internal utilities for use by analyzers.
@@ -128,7 +129,8 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                 result = SyntaxFactory.QualifiedName(result, rightSide);
             }
 
-            return SyntaxFactory.QualifiedName(result, simpleName);
+            return SyntaxFactory.QualifiedName(result, simpleName)
+                .WithAdditionalAnnotations(Simplifier.Annotation);
         }
 
         private static bool LaunchDebuggerExceptionFilter()

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     /// Discovers VS packages that derive directly from <see cref="Package"/> instead of <see cref="AsyncPackage"/>.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class VSSDK001DeriveFromAsyncPackage : DiagnosticAnalyzer
+    public class VSSDK001DeriveFromAsyncPackageAnalyzer : DiagnosticAnalyzer
     {
         /// <summary>
         /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
@@ -6,7 +6,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -14,7 +13,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis.Simplification;
 
     /// <summary>
     /// Offers code fixes for diagnostics produced by the <see cref="VSSDK001DeriveFromAsyncPackageAnalyzer"/>.
@@ -38,24 +36,104 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             var classDeclarationSyntax = baseTypeSyntax.FirstAncestorOrSelf<ClassDeclarationSyntax>();
 
             context.RegisterCodeFix(
-                CodeAction.Create("Change base type to AsyncPackage", ct => this.ChangeBaseTypeAsync(context.Document, diagnostic, ct), classDeclarationSyntax.Identifier.ToString()),
+                CodeAction.Create("Convert to async package", ct => this.ConvertToAsyncPackageAsync(context.Document, diagnostic, ct), classDeclarationSyntax.Identifier.ToString()),
                 diagnostic);
         }
 
         /// <inheritdoc />
         public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-        private async Task<Document> ChangeBaseTypeAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        private async Task<Document> ConvertToAsyncPackageAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var baseTypeSyntax = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<BaseTypeSyntax>();
             var classDeclarationSyntax = baseTypeSyntax.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            var initializeMethodSyntax = classDeclarationSyntax.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .FirstOrDefault(method => method.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.OverrideKeyword)) && method.Identifier.Text == Types.AsyncPackage.Initialize);
+            var baseInitializeInvocationSyntax = initializeMethodSyntax?.Body?.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .FirstOrDefault(ies => ies.Expression is MemberAccessExpressionSyntax memberAccess && memberAccess.Name?.Identifier.Text == Types.AsyncPackage.Initialize && memberAccess.Expression is BaseExpressionSyntax);
 
-            var asyncPackageBaseTypeSyntax = SyntaxFactory.SimpleBaseType(Utils.QualifyName(Types.AsyncPackage.Namespace, SyntaxFactory.IdentifierName(Types.AsyncPackage.TypeName)))
-                .WithAdditionalAnnotations(Simplifier.Annotation)
+            // Make it easier to track nodes across changes.
+            var nodesToTrack = new List<SyntaxNode>
+            {
+                baseTypeSyntax,
+                initializeMethodSyntax,
+                baseInitializeInvocationSyntax,
+            };
+            nodesToTrack.RemoveAll(n => n == null);
+            var updatedRoot = root.TrackNodes(nodesToTrack);
+
+            // Replace the Package base type with AsyncPackage
+            baseTypeSyntax = updatedRoot.GetCurrentNode(baseTypeSyntax);
+            var asyncPackageBaseTypeSyntax = SyntaxFactory.SimpleBaseType(Types.AsyncPackage.TypeSyntax)
                 .WithLeadingTrivia(baseTypeSyntax.GetLeadingTrivia())
                 .WithTrailingTrivia(baseTypeSyntax.GetTrailingTrivia());
-            var updatedRoot = root.ReplaceNode(baseTypeSyntax, asyncPackageBaseTypeSyntax);
+            updatedRoot = updatedRoot.ReplaceNode(baseTypeSyntax, asyncPackageBaseTypeSyntax);
+
+            // Find the Initialize override, if present, and update it to InitializeAsync
+            if (initializeMethodSyntax != null)
+            {
+                var cancellationTokenLocalVarName = SyntaxFactory.IdentifierName("cancellationToken");
+                var progressLocalVarName = SyntaxFactory.IdentifierName("progress");
+                initializeMethodSyntax = updatedRoot.GetCurrentNode(initializeMethodSyntax);
+                var newBody = initializeMethodSyntax.Body;
+                if (baseInitializeInvocationSyntax != null)
+                {
+                    var baseInitializeAsyncInvocationBookmark = new SyntaxAnnotation();
+                    var baseInitializeAsyncInvocationSyntax = SyntaxFactory.AwaitExpression(
+                        baseInitializeInvocationSyntax
+                            .WithLeadingTrivia()
+                            .WithExpression(
+                                SyntaxFactory.MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    SyntaxFactory.BaseExpression(),
+                                    SyntaxFactory.IdentifierName(Types.AsyncPackage.InitializeAsync)))
+                            .AddArgumentListArguments(
+                                SyntaxFactory.Argument(cancellationTokenLocalVarName),
+                                SyntaxFactory.Argument(progressLocalVarName)))
+                        .WithLeadingTrivia(baseInitializeInvocationSyntax.GetLeadingTrivia())
+                        .WithAdditionalAnnotations(baseInitializeAsyncInvocationBookmark);
+                    newBody = newBody.ReplaceNode(initializeMethodSyntax.GetCurrentNode(baseInitializeInvocationSyntax), baseInitializeAsyncInvocationSyntax);
+                    var baseInvocationStatement = newBody.GetAnnotatedNodes(baseInitializeAsyncInvocationBookmark).First().FirstAncestorOrSelf<StatementSyntax>();
+
+                    var leadingTrivia = SyntaxFactory.TriviaList(
+                        SyntaxFactory.LineFeed,
+                        SyntaxFactory.Comment(@"// When initialized asynchronously, we *may* be on a background thread at this point."),
+                        SyntaxFactory.LineFeed,
+                        SyntaxFactory.Comment(@"// Do any initialization that requires the UI thread after switching to the UI thread."),
+                        SyntaxFactory.LineFeed,
+                        SyntaxFactory.Comment(@"// Otherwise, remove the switch to the UI thread if you don't need it."),
+                        SyntaxFactory.LineFeed);
+
+                    var switchToMainThreadStatement = SyntaxFactory.ExpressionStatement(
+                        SyntaxFactory.AwaitExpression(
+                            SyntaxFactory.InvocationExpression(
+                                SyntaxFactory.MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    SyntaxFactory.MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        Types.ThreadHelper.TypeSyntax,
+                                        SyntaxFactory.IdentifierName(Types.ThreadHelper.JoinableTaskFactory)),
+                                    SyntaxFactory.IdentifierName(Types.JoinableTaskFactory.SwitchToMainThreadAsync)))
+                                .AddArgumentListArguments(SyntaxFactory.Argument(cancellationTokenLocalVarName))))
+                        .WithLeadingTrivia(leadingTrivia)
+                        .WithTrailingTrivia(SyntaxFactory.LineFeed);
+
+                    newBody = newBody.InsertNodesAfter(baseInvocationStatement, new[] { switchToMainThreadStatement });
+                }
+
+                var initializeAsyncMethodSyntax = initializeMethodSyntax
+                    .WithIdentifier(SyntaxFactory.Identifier(Types.AsyncPackage.InitializeAsync))
+                    .WithReturnType(Types.Task.TypeSyntax)
+                    .AddModifiers(SyntaxFactory.Token(SyntaxKind.AsyncKeyword))
+                    .AddParameterListParameters(
+                        SyntaxFactory.Parameter(cancellationTokenLocalVarName.Identifier).WithType(Types.CancellationToken.TypeSyntax),
+                        SyntaxFactory.Parameter(progressLocalVarName.Identifier).WithType(Types.IProgress.TypeSyntaxOf(Types.ServiceProgressData.TypeSyntax)))
+                    .WithBody(newBody);
+                updatedRoot = updatedRoot.ReplaceNode(initializeMethodSyntax, initializeAsyncMethodSyntax);
+            }
 
             return document.WithSyntaxRoot(updatedRoot);
         }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Simplification;
+
+    /// <summary>
+    /// Offers code fixes for diagnostics produced by the <see cref="VSSDK001DeriveFromAsyncPackageAnalyzer"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public class VSSDK001DeriveFromAsyncPackageCodeFix : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
+          VSSDK001DeriveFromAsyncPackageAnalyzer.Descriptor.Id);
+
+        /// <inheritdoc />
+        public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;
+
+        /// <inheritdoc />
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var baseTypeSyntax = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<BaseTypeSyntax>();
+            var classDeclarationSyntax = baseTypeSyntax.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+
+            context.RegisterCodeFix(
+                CodeAction.Create("Change base type to AsyncPackage", ct => this.ChangeBaseTypeAsync(context.Document, diagnostic, ct), classDeclarationSyntax.Identifier.ToString()),
+                diagnostic);
+        }
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        private async Task<Document> ChangeBaseTypeAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var baseTypeSyntax = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<BaseTypeSyntax>();
+            var classDeclarationSyntax = baseTypeSyntax.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+
+            var asyncPackageBaseTypeSyntax = SyntaxFactory.SimpleBaseType(Utils.QualifyName(Types.AsyncPackage.Namespace, SyntaxFactory.IdentifierName(Types.AsyncPackage.TypeName)))
+                .WithAdditionalAnnotations(Simplifier.Annotation)
+                .WithLeadingTrivia(baseTypeSyntax.GetLeadingTrivia())
+                .WithTrailingTrivia(baseTypeSyntax.GetTrailingTrivia());
+            var updatedRoot = root.ReplaceNode(baseTypeSyntax, asyncPackageBaseTypeSyntax);
+
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+    }
+}


### PR DESCRIPTION
This automatically changes the base type from `Package` to `AsyncPackage`

In the future, it can apply more changes like update the Initialize override, etc.

This is a rather large change because with it comes the testing infrastructure to support testing code fix providers.