### PR TITLE
Add VSSDK002 to detect PackageRegistration mismatches with package base type

### DIFF
--- a/doc/VSSDK002.md
+++ b/doc/VSSDK002.md
@@ -38,3 +38,5 @@ or
 class MyCoolPackage : AsyncPackage {
 }
 ```
+
+A code fix is offered for this diagnostic to automatically apply this change.

--- a/doc/VSSDK002.md
+++ b/doc/VSSDK002.md
@@ -1,0 +1,40 @@
+# VSSDK002 PackageRegistration matches Package
+
+The `PackageRegistrationAttribute.AllowsBackgroundLoading` parameter on your VS package class
+should indicate whether your class derives from `AsyncPackage`.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class MyCoolPackage : AsyncPackage {
+}
+```
+
+or
+
+```csharp
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class MyCoolPackage : Package {
+}
+```
+
+## Solution
+
+Update the PackageRegistration attribute to match the base type of your package class.
+Specifically, the `AllowsBackgroundLoading` parameter should be set to `true`
+if and only if your package derives from `AsyncPackage`.
+
+```csharp
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class MyCoolPackage : Package {
+}
+```
+
+or
+
+```csharp
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class MyCoolPackage : AsyncPackage {
+}
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -3,8 +3,9 @@
 The following are the diagnostic analyzers installed with the [Microsoft.VisualStudio.SDK.Analyzers][1]
 NuGet package.
 
-ID | Title | Severity
+ID | Title | Category
 ---- | --- | --- |
 [VSSDK001](VSSDK001.md) | Derive from AsyncPackage | Performance
+[VSSDK002](VSSDK002.md) | PackageRegistration matches Package | Performance
 
 [1]: https://nuget.org/packages/microsoft.visualstudio.sdk.analyzers

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
          due to issue https://github.com/dotnet/project-system/issues/2129 -->
     <PackageReference Include="GitLink" Version="3.2.0-unstable0018" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.53" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.17" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/AnalyzerAssemblyTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/AnalyzerAssemblyTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.Shell;
+    using Xunit;
+
+    public class AnalyzerAssemblyTests
+    {
+        /// <summary>
+        /// Verifies that although we compile against MPF for convenience in referencing its types at compile-time,
+        /// we maintain that we never compile into an assembly that still references it, since it may not be around at runtime for the CLR to find.
+        /// </summary>
+        [Fact]
+        public void AssemblyHasNoReferenceToMpf()
+        {
+            Assert.DoesNotContain(
+                typeof(VSSDK001DeriveFromAsyncPackageAnalyzer).Assembly.GetReferencedAssemblies(),
+                a => a.Name.StartsWith("Microsoft.VisualStudio", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -155,7 +155,7 @@ class Test : Microsoft.VisualStudio.Shell.AsyncPackage
         // When initialized asynchronously, we *may* be on a background thread at this point.
         // Do any initialization that requires the UI thread after switching to the UI thread.
         // Otherwise, remove the switch to the UI thread if you don't need it.
-        await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         Console.WriteLine(""after"");
     }
@@ -196,7 +196,7 @@ class Test : AsyncPackage
         // When initialized asynchronously, we *may* be on a background thread at this point.
         // Do any initialization that requires the UI thread after switching to the UI thread.
         // Otherwise, remove the switch to the UI thread if you don't need it.
-        await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var shell = await this.GetServiceAsync(typeof(SVsShell)) as IVsShell;
     }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.SDK.Analyzers;
+using Microsoft.VisualStudio.SDK.Analyzers.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+public class VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests : DiagnosticVerifier
+{
+    private DiagnosticResult expect = new DiagnosticResult
+    {
+        Id = VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.Id,
+        SkipVerifyMessage = true,
+        Severity = DiagnosticSeverity.Error,
+    };
+
+    public VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void AsyncPackageWithNoAttributeProducesNoDiagnostic()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test : AsyncPackage {
+}
+";
+
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void PackageRegistrationWithNoBaseType()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class Test {
+}
+";
+
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void PackageRegistrationWithIrrelevant()
+    {
+        var test = @"
+using System;
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class Test : IDisposable {
+    public void Dispose() { }
+}
+";
+
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void AsyncPackageMatchProducesNoDiagnostic()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class Test : AsyncPackage {
+}
+";
+
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void PackageMatchProducesNoDiagnostic()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class MyCoolPackage : Package {
+}
+";
+
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void AsyncPackageMismatchProducesDiagnostic()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class Test : AsyncPackage {
+}
+";
+
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 14, 5, 26) };
+        this.VerifyCSharpDiagnostic(test, this.expect);
+    }
+
+    [Fact]
+    public void PackageMismatchProducesDiagnostic()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class MyCoolPackage : Package {
+}
+";
+
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 54, 4, 84) };
+        this.VerifyCSharpDiagnostic(test, this.expect);
+    }
+
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer();
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -40,6 +40,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
             /// </summary>
             internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -168,6 +173,37 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
             /// </summary>
             internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.PackageRegistrationAttribute"/> type.
+        /// </summary>
+        internal static class PackageRegistrationAttribute
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.PackageRegistrationAttribute"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.PackageRegistrationAttribute);
+
+            /// <summary>
+            /// Gets the name of the <see cref="Shell.PackageRegistrationAttribute.AllowsBackgroundLoading"/> property.
+            /// </summary>
+            internal const string AllowsBackgroundLoading = nameof(Shell.PackageRegistrationAttribute.AllowsBackgroundLoading);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -22,14 +22,40 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             internal const string TypeName = nameof(Shell.AsyncPackage);
 
             /// <summary>
-            /// The name of the Initialize method.
-            /// </summary>
-            internal const string Initialize = "Initialize";
-
-            /// <summary>
             /// The name of the InitializeAsync method.
             /// </summary>
             internal const string InitializeAsync = "InitializeAsync";
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.Package"/> type.
+        /// </summary>
+        internal static class Package
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.Package"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.Package);
+
+            /// <summary>
+            /// The name of the Initialize method.
+            /// </summary>
+            internal const string Initialize = "Initialize";
 
             /// <summary>
             /// Gets an array of the nesting namespaces for this type.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             title: "Derive from AsyncPackage",
             messageFormat: "Your Package-derived class should derive from AsyncPackage instead.",
             helpLinkUri: Utils.GetHelpLink(Id),
-            category: "Usage",
+            category: "Performance",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageAnalyzer.cs
@@ -33,8 +33,13 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
+        /// <summary>
+        /// A cached array for the <see cref="SupportedDiagnostics"/> property.
+        /// </summary>
+        private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDiagnostics = ImmutableArray.Create(Descriptor);
+
         /// <inheritdoc />
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDiagnostics;
 
         /// <inheritdoc />
         public override void Initialize(AnalysisContext context)

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
@@ -50,10 +50,10 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             var classDeclarationSyntax = baseTypeSyntax.FirstAncestorOrSelf<ClassDeclarationSyntax>();
             var initializeMethodSyntax = classDeclarationSyntax.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
-                .FirstOrDefault(method => method.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.OverrideKeyword)) && method.Identifier.Text == Types.AsyncPackage.Initialize);
+                .FirstOrDefault(method => method.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.OverrideKeyword)) && method.Identifier.Text == Types.Package.Initialize);
             var baseInitializeInvocationSyntax = initializeMethodSyntax?.Body?.DescendantNodes()
                 .OfType<InvocationExpressionSyntax>()
-                .FirstOrDefault(ies => ies.Expression is MemberAccessExpressionSyntax memberAccess && memberAccess.Name?.Identifier.Text == Types.AsyncPackage.Initialize && memberAccess.Expression is BaseExpressionSyntax);
+                .FirstOrDefault(ies => ies.Expression is MemberAccessExpressionSyntax memberAccess && memberAccess.Name?.Identifier.Text == Types.Package.Initialize && memberAccess.Expression is BaseExpressionSyntax);
 
             // Make it easier to track nodes across changes.
             var nodesToTrack = new List<SyntaxNode>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK001DeriveFromAsyncPackageCodeFix.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                                     SyntaxKind.SimpleMemberAccessExpression,
                                     SyntaxFactory.MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
-                                        Types.ThreadHelper.TypeSyntax,
+                                        SyntaxFactory.ThisExpression(),
                                         SyntaxFactory.IdentifierName(Types.ThreadHelper.JoinableTaskFactory)),
                                     SyntaxFactory.IdentifierName(Types.JoinableTaskFactory.SwitchToMainThreadAsync)))
                                 .AddArgumentListArguments(SyntaxFactory.Argument(cancellationTokenLocalVarName))))

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.Shell;
+
+    /// <summary>
+    /// Identifies cases where an <see cref="AsyncPackage"/> isn't tagged as such in the <see cref="PackageRegistrationAttribute"/>,
+    /// or a <see cref="Package"/> is tagged as async inappropriately.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+        /// </summary>
+        public const string Id = "VSSDK002";
+
+        /// <summary>
+        /// A reusable descriptor for diagnostics produced by this analyzer.
+        /// </summary>
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: "PackageRegistration matches Package",
+            messageFormat: "The PackageRegistrationAttribute.AllowsBackgroundLoading should be set to true if and only if the package derives from AsyncPackage.",
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Performance",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            // Register for compilation first so that we only activate the analyzer for applicable compilations
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                var packageType = compilationContext.Compilation.GetTypeByMetadataName(typeof(Package).FullName)?.OriginalDefinition;
+                var asyncPackageType = compilationContext.Compilation.GetTypeByMetadataName(typeof(AsyncPackage).FullName)?.OriginalDefinition;
+                if (packageType != null && asyncPackageType != null)
+                {
+                    // Reuse the type symbols we looked up so that we don't have to look them up for every single class declaration.
+                    compilationContext.RegisterSyntaxNodeAction(
+                        Utils.DebuggableWrapper(ctxt => this.AnalyzeClassDeclaration(ctxt, packageType, asyncPackageType)),
+                        SyntaxKind.ClassDeclaration);
+                }
+            });
+        }
+
+        private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol packageType, INamedTypeSymbol asyncPackageType)
+        {
+            var declaration = (ClassDeclarationSyntax)context.Node;
+            var baseType = declaration.BaseList?.Types.FirstOrDefault();
+            if (baseType == null)
+            {
+                return;
+            }
+
+            var baseTypeSymbol = context.SemanticModel.GetSymbolInfo(baseType.Type, context.CancellationToken).Symbol?.OriginalDefinition as ITypeSymbol;
+
+            if (Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, packageType))
+            {
+                var packageRegistrationType = context.Compilation.GetTypeByMetadataName(Types.PackageRegistrationAttribute.FullName);
+                var userClassSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+                var packageRegistrationInstance = userClassSymbol?.GetAttributes().FirstOrDefault(a => a.AttributeClass == packageRegistrationType);
+                if (packageRegistrationInstance == null)
+                {
+                    return;
+                }
+
+                if (!(packageRegistrationInstance.NamedArguments.FirstOrDefault(kv => kv.Key == Types.PackageRegistrationAttribute.AllowsBackgroundLoading).Value.Value is bool allowsBackgroundLoading))
+                {
+                    allowsBackgroundLoading = false;
+                }
+
+                bool isAsyncPackageBaseType = Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, asyncPackageType);
+
+                if (isAsyncPackageBaseType != allowsBackgroundLoading)
+                {
+                    var attributeSyntax = packageRegistrationInstance.ApplicationSyntaxReference.GetSyntax(context.CancellationToken) as AttributeSyntax;
+                    var allowBackgroundLoadingSyntax = attributeSyntax?.ArgumentList.Arguments.FirstOrDefault(a => a.NameEquals?.Name?.Identifier.Text == Types.PackageRegistrationAttribute.AllowsBackgroundLoading);
+                    Location relevantLocation = allowBackgroundLoadingSyntax?.GetLocation() ?? baseType.GetLocation();
+
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        Descriptor,
+                        relevantLocation));
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK002PackageRegistrationMatchesBaseTypeCodeFix.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK002PackageRegistrationMatchesBaseTypeCodeFix.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    /// <summary>
+    /// Offers code fixes for diagnostics produced by the <see cref="VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public class VSSDK002PackageRegistrationMatchesBaseTypeCodeFix : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> ReusableFixableDiagnosticIds = ImmutableArray.Create(
+          VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.Descriptor.Id);
+
+        /// <inheritdoc />
+        public override ImmutableArray<string> FixableDiagnosticIds => ReusableFixableDiagnosticIds;
+
+        /// <inheritdoc />
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var diagnostic = context.Diagnostics.First();
+
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var classDeclarationSyntax = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            if (classDeclarationSyntax != null)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create("Fix attribute to match package type", ct => this.UpdateAttributeAsync(context, diagnostic, ct), classDeclarationSyntax.Identifier.ToString()),
+                    diagnostic);
+            }
+        }
+
+        /// <inheritdoc />
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        private async Task<Document> UpdateAttributeAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            bool isAsyncPackage = diagnostic.Properties[VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.BaseTypeDiagnosticPropertyName] == Types.AsyncPackage.TypeName;
+            LiteralExpressionSyntax appropriateArgument = SyntaxFactory.LiteralExpression(isAsyncPackage ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression);
+
+            var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            switch (root.FindNode(diagnostic.Location.SourceSpan))
+            {
+                case AttributeSyntax packageRegistrationSyntax:
+                    // We need to add an argument to this attribute
+                    root = root.ReplaceNode(
+                        packageRegistrationSyntax,
+                        packageRegistrationSyntax.AddArgumentListArguments(
+                            SyntaxFactory.AttributeArgument(appropriateArgument).WithNameEquals(SyntaxFactory.NameEquals(Types.PackageRegistrationAttribute.AllowsBackgroundLoading))));
+                    break;
+                case AttributeArgumentSyntax allowBackgroundLoadingSyntax:
+                    if (isAsyncPackage)
+                    {
+                        // We need to update this argument on the attribute.
+                        AttributeSyntax originalAttribute = allowBackgroundLoadingSyntax.FirstAncestorOrSelf<AttributeSyntax>();
+                        root = root.ReplaceNode(allowBackgroundLoadingSyntax, allowBackgroundLoadingSyntax.WithExpression(appropriateArgument));
+                    }
+                    else
+                    {
+                        // Let's just remove it since false is its default value.
+                        root = root.RemoveNode(allowBackgroundLoadingSyntax, SyntaxRemoveOptions.KeepNoTrivia);
+                    }
+
+                    break;
+                case SyntaxNode node:
+                    throw new InvalidOperationException("Unexpected syntax type: " + node.GetType().Name);
+            }
+
+            return context.Document.WithSyntaxRoot(root);
+        }
+    }
+}


### PR DESCRIPTION
Besides adding the analyzer and code fix, this also fixes VSSDK001 to not run unless `AsyncPackage` is actually an option given the target version of VS.

Closes #16 