### PR TITLE
Re-enable cloud build numbers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ environment:
   VisualStudioVersion: 15.0
   TreatWarningsAsErrors: true
   CodeAnalysisTreatWarningsAsErrors: true
+  codecov_token: 27bb1787-08af-48c7-bda5-ca308440f1b6
 before_build:
 - msbuild src\Microsoft.VisualStudio.SDK.Analyzers.sln /nologo /m /v:quiet /t:restore
 - choco install opencover.portable

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Analyzers for VS extensions
 
 [![Build status](https://ci.appveyor.com/api/projects/status/d04ivfn3ad15b902/branch/master?svg=true)](https://ci.appveyor.com/project/AArnott/vssdk-analyzers/branch/master)
+[![codecov](https://codecov.io/gh/microsoft/vssdk-analyzers/branch/master/graph/badge.svg)](https://codecov.io/gh/microsoft/vssdk-analyzers)
 
 This project is meant to provide a set of Roslyn Analyzers that makes it easy to catch, discover and implement a wide array of best practices when building Visual Studio extensions.
 
 Check out our [exhaustive list of analyzers](doc/index.md) defined in this project.
 
-If you have an idea for a rule that would constitute a best practice for extension authors to follow, please open an issue with the description. 
+If you have an idea for a rule that would constitute a best practice for extension authors to follow, please open an issue with the description.
 
 # Contributing
 

--- a/src/version.json
+++ b/src/version.json
@@ -7,7 +7,7 @@
   ],
   "cloudBuild": {
     "buildNumber": {
-      "enabled": false
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
With help from codecov.io, we can now have cloud build numbers *and* codecov working at once.
[![image](https://user-images.githubusercontent.com/3548/36067801-2d5cf798-0e7a-11e8-87de-100c72dfcb36.png)](https://ci.appveyor.com/project/AArnott/vssdk-analyzers/history)


With this change I also add a badge showing off our code coverage % on the README next to the appveyor badge.