### PR TITLE
Enhance VSSDK001 code fix to migrate to AsyncPackage more completely

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -35,13 +35,35 @@ class Test : AsyncPackage
         this.VerifyCSharpFix(test, withFix);
     }
 
-    [Fact(Skip = "Not yet implemented")]
-    public void PackageRegistrationUpdated()
+    [Fact]
+    public void PackageRegistrationUpdated_NewArgument()
     {
         var test = @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true)]
+class Test : Package
+{
+}
+";
+        var withFix = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class Test : AsyncPackage
+{
+}
+";
+        this.VerifyCSharpFix(test, withFix);
+    }
+
+    [Fact]
+    public void PackageRegistrationUpdated_ExistingArgument()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = false)]
 class Test : Package
 {
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -186,7 +186,7 @@ class Test : Microsoft.VisualStudio.Shell.AsyncPackage
         this.VerifyCSharpFix(test, withFix);
     }
 
-    [Fact(Skip = "Not yet implemented")]
+    [Fact]
     public void InitializeOverride_GetServiceCallsUpdated()
     {
         var test = @"
@@ -201,6 +201,8 @@ class Test : Package
         base.Initialize(); // base invocation
 
         var shell = this.GetService(typeof(SVsShell)) as IVsShell;
+        var shell2 = GetService(typeof(SVsShell)) as IVsShell;
+        var shell3 = GetService(typeof(SVsShell)).ToString();
     }
 }
 ";
@@ -221,6 +223,8 @@ class Test : AsyncPackage
         await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
         var shell = await this.GetServiceAsync(typeof(SVsShell)) as IVsShell;
+        var shell2 = await GetServiceAsync(typeof(SVsShell)) as IVsShell;
+        var shell3 = (await GetServiceAsync(typeof(SVsShell))).ToString();
     }
 }
 ";

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -231,12 +231,6 @@ class Test : AsyncPackage
         this.VerifyCSharpFix(test, withFix);
     }
 
-    [Fact(Skip = "Not yet implemented")]
-    public void InitializeOverride_AddServiceDelegatesMadeAsync()
-    {
-        // TODO
-    }
-
     protected override CodeFixProvider GetCSharpCodeFixProvider() => new VSSDK001DeriveFromAsyncPackageCodeFix();
 
     protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK001DeriveFromAsyncPackageAnalyzer();

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -27,6 +27,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             internal const string InitializeAsync = "InitializeAsync";
 
             /// <summary>
+            /// The name of the GetServiceAsync method.
+            /// </summary>
+            internal const string GetServiceAsync = "GetServiceAsync";
+
+            /// <summary>
             /// Gets an array of the nesting namespaces for this type.
             /// </summary>
             internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
@@ -56,6 +61,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// The name of the Initialize method.
             /// </summary>
             internal const string Initialize = "Initialize";
+
+            /// <summary>
+            /// The name of the GetService method.
+            /// </summary>
+            internal const string GetService = "GetService";
 
             /// <summary>
             /// Gets an array of the nesting namespaces for this type.


### PR DESCRIPTION
The VSSDK001 code fix now also:

1. updates the `PackageRegistrationAttribute.AllowBackgroundLoading` property
1. Replaces `GetService` calls that were in the old `Initialize` override with `GetServiceAsync` calls in the new `InitializeAsync` override.

![codefix](https://user-images.githubusercontent.com/3548/36074896-6ac3890e-0efb-11e8-8bb5-0d9a9943b9f5.gif)

I also remove a test as a wave of the white flag against the goal of updating all the `IServiceContainer.AddService` calls in the `Initialize` method to use the async service container. So many variants of how the syntax might look -- it's possible, but would be a ton of work so I'll wait for feedback to justify doing it.