### PR TITLE
Add VSSDK003 Support async tool windows

### DIFF
--- a/doc/VSSDK003.md
+++ b/doc/VSSDK003.md
@@ -1,0 +1,80 @@
+# VSSDK003 Support async tool windows
+
+Offer an async tool window factory for your tool windows so Visual Studio startup
+is fast if the tool window is initially visible, and remains responsive when your
+tool window is activated later in the session.
+
+This analyzer only flags synchronous tool windows when proffered from an `AsyncPackage`-derived
+VS package and when targeting Visual Studio 2017 Update 6 or later.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+[Guid("bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5")]
+public class ToolWindow1 : ToolWindowPane
+{
+    public ToolWindow1() : base(null)
+    {
+        this.Caption = "ToolWindow1";
+        this.Content = new ToolWindow1Control();
+    }
+}
+
+public class ToolWindow1Package : AsyncPackage
+{
+    // A lack of async tool window factory overrides
+}
+```
+
+## Solution
+
+Override the async tool window factory methods on your `AsyncPackage`-derived class
+and offer a constructor overload in your `ToolWindowPane`-derived class that accepts one parameter.
+
+```csharp
+[Guid("bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5")]
+public class ToolWindow1 : ToolWindowPane
+{
+    public ToolWindow1() : base(null)
+    {
+        this.Caption = "ToolWindow1";
+        this.Content = new ToolWindow1Control();
+    }
+
+    public ToolWindow1(string message)
+        : this()
+    {
+    }
+}
+
+public class ToolWindow1Package : AsyncPackage
+{
+    public override IVsAsyncToolWindowFactory GetAsyncToolWindowFactory(Guid toolWindowType)
+    {
+        if (toolWindowType == typeof(ToolWindow1).GUID)
+        {
+            return this;
+        }
+
+        return base.GetAsyncToolWindowFactory(toolWindowType);
+    }
+
+    protected override string GetToolWindowTitle(Type toolWindowType, int id)
+    {
+        if (toolWindowType == typeof(ToolWindow1))
+        {
+            return "ToolWindow1 loading";
+        }
+
+        return base.GetToolWindowTitle(toolWindowType, id);
+    }
+
+    protected override async Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
+    {
+        // potentially expensive work, preferably done on a background thread where possible.
+        await Task.Delay(5000, cancellationToken);
+
+        return "foo"; // this is passed to the tool window constructor
+    }
+}
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -7,5 +7,6 @@ ID | Title | Category
 ---- | --- | --- |
 [VSSDK001](VSSDK001.md) | Derive from AsyncPackage | Performance
 [VSSDK002](VSSDK002.md) | PackageRegistration matches Package | Performance
+[VSSDK003](VSSDK003.md) | Support async tool windows | Performance
 
 [1]: https://nuget.org/packages/microsoft.visualstudio.sdk.analyzers

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,8 +23,12 @@
     <PackageReference Include="GitLink" Version="3.2.0-unstable0018" PrivateAssets="all" />
     <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.53" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="all" />
+    <PackageReference Include="StreamJsonRpc" Version="1.3.23" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.17" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.4.27004" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.6.27415" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0" Version="14.3.26929" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.6.31" PrivateAssets="all" />
 
     <!-- We WANT these analyzers to be expressed as dependencies of the final package. -->
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="none" />

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using System.Windows.Controls;
     using Microsoft.Build.Utilities;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -24,14 +25,23 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
         private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
         private static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(Debug).Assembly.Location);
+        private static readonly MetadataReference PresentationFrameworkReference = MetadataReference.CreateFromFile(typeof(UserControl).Assembly.Location);
         private static readonly MetadataReference MPFReference = MetadataReference.CreateFromFile(typeof(Package).Assembly.Location);
 
         private static readonly ImmutableArray<string> VSSDKPackageReferences = ImmutableArray.Create(new string[]
         {
-            Path.Combine("Microsoft.VisualStudio.Shell.Interop", "7.10.6071", "lib", "Microsoft.VisualStudio.Shell.Interop.dll"),
-            Path.Combine("Microsoft.VisualStudio.Shell.15.0", "15.4.27004", "lib", "Microsoft.VisualStudio.Shell.15.0.dll"),
-            Path.Combine("Microsoft.VisualStudio.Shell.Framework", "15.4.27004", "lib\\net45", "Microsoft.VisualStudio.Shell.Framework.dll"),
-            Path.Combine("Microsoft.VisualStudio.Threading", "15.4.4", "lib\\net45", "Microsoft.VisualStudio.Threading.dll"),
+            Path.Combine("Microsoft.VisualStudio.OLE.Interop", "7.10.6071", "lib", "Microsoft.VisualStudio.OLE.Interop.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop", "7.10.6072", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.8.0", "8.0.50728", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.8.0.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.9.0", "9.0.30730", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.9.0.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.10.0", "10.0.30320", "lib\\net20", "Microsoft.VisualStudio.Shell.Interop.10.0.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.11.0", "11.0.61031", "lib\\net20", "Microsoft.VisualStudio.Shell.Interop.11.0.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.14.0", "14.3.26929", "lib\\net20", "Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime", "15.0.26929", "lib\\net20", "Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime", "15.6.27415", "lib\\net20", "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.15.0", "15.6.27415", "lib\\net45", "Microsoft.VisualStudio.Shell.15.0.dll"),
+            Path.Combine("Microsoft.VisualStudio.Shell.Framework", "15.6.27415", "lib\\net45", "Microsoft.VisualStudio.Shell.Framework.dll"),
+            Path.Combine("Microsoft.VisualStudio.Threading", "15.6.31", "lib\\net45", "Microsoft.VisualStudio.Threading.dll"),
         });
 
         private static string csharpDefaultFileExt = "cs";
@@ -133,6 +143,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
                 .AddProject(projectId, testProjectName, testProjectName, language)
                 .AddMetadataReference(projectId, CorlibReference)
                 .AddMetadataReference(projectId, SystemReference)
+                .AddMetadataReference(projectId, PresentationFrameworkReference)
                 .AddMetadataReference(projectId, SystemCoreReference)
                 .AddMetadataReference(projectId, MPFReference)
                 .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(hasEntrypoint ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary))
@@ -225,6 +236,17 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
         protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
         {
             this.VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers(), allowErrors: false, expected: expected);
+        }
+
+        /// <summary>
+        /// Called to test a C# DiagnosticAnalyzer when applied on multiple inputted string as a source
+        /// Note: input a DiagnosticResult for each Diagnostic expected
+        /// </summary>
+        /// <param name="sources">Classes, each in the form of a string to run the analyzer on</param>
+        /// <param name="expected">An array of <see cref="DiagnosticResult"/> that should appear after the analyzer is run on the source</param>
+        protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
+        {
+            this.VerifyDiagnostics(sources, LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers(), allowErrors: false, expected: expected);
         }
 
         protected void LogFileContent(string source)

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
         }
 
         /// <summary>
-        /// Called to test a C# DiagnosticAnalyzer when applied on multiple inputted string as a source
+        /// Called to test a C# DiagnosticAnalyzer when applied on multiple input strings as a source
         /// Note: input a DiagnosticResult for each Diagnostic expected
         /// </summary>
         /// <param name="sources">Classes, each in the form of a string to run the analyzer on</param>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
@@ -24,4 +24,8 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.SDK.Analyzers\Microsoft.VisualStudio.SDK.Analyzers.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK003SupportAsyncToolWindowAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK003SupportAsyncToolWindowAnalyzerTests.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.SDK.Analyzers;
+using Microsoft.VisualStudio.SDK.Analyzers.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+public class VSSDK003SupportAsyncToolWindowAnalyzerTests : DiagnosticVerifier
+{
+    private DiagnosticResult expect = new DiagnosticResult
+    {
+        Id = VSSDK003SupportAsyncToolWindowAnalyzer.Id,
+        SkipVerifyMessage = true,
+        Severity = DiagnosticSeverity.Info,
+    };
+
+    public VSSDK003SupportAsyncToolWindowAnalyzerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void SyncToolWindow_NonAsyncPackage_ProducesDiagnostic()
+    {
+        var package = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideToolWindow(typeof(ToolWindow1))]
+class ToolWindow1Package : Package
+{
+}
+";
+        var toolWindow = @"
+using System.Runtime.InteropServices;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell;
+
+[Guid(""bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5"")]
+public class ToolWindow1 : ToolWindowPane
+{
+    public ToolWindow1() : base(null)
+    {
+        this.Caption = ""ToolWindow1"";
+        this.Content = new UserControl();
+    }
+}
+";
+
+        this.VerifyCSharpDiagnostic(new[] { package, toolWindow });
+    }
+
+    [Fact]
+    public void SyncToolWindow_AsyncPackage_ProducesDiagnostic()
+    {
+        var package = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideToolWindow(typeof(ToolWindow1))]
+class ToolWindow1Package : AsyncPackage
+{
+}
+";
+        var toolWindow = @"
+using System.Runtime.InteropServices;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell;
+
+[Guid(""bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5"")]
+public class ToolWindow1 : ToolWindowPane
+{
+    public ToolWindow1() : base(null)
+    {
+        this.Caption = ""ToolWindow1"";
+        this.Content = new UserControl();
+    }
+}
+";
+
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 27, 4, 38) };
+        this.VerifyCSharpDiagnostic(new[] { package, toolWindow }, this.expect);
+    }
+
+    [Fact]
+    public void AsyncToolWindow_ProducesNoDiagnostic()
+    {
+        var package = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+[ProvideToolWindow(typeof(ToolWindow1))]
+class ToolWindow1Package : AsyncPackage
+{
+    public override IVsAsyncToolWindowFactory GetAsyncToolWindowFactory(Guid toolWindowType)
+    {
+        if (toolWindowType == typeof(ToolWindow1).GUID)
+        {
+            return this;
+        }
+
+        return base.GetAsyncToolWindowFactory(toolWindowType);
+    }
+
+    protected override string GetToolWindowTitle(Type toolWindowType, int id)
+    {
+        if (toolWindowType == typeof(ToolWindow1))
+        {
+            return ""ToolWindow1 loading"";
+        }
+
+        return base.GetToolWindowTitle(toolWindowType, id);
+    }
+
+    protected override async Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
+    {
+        await Task.Delay(5000);
+
+        return ""foo"";
+    }
+}
+";
+        var toolWindow = @"
+using System.Runtime.InteropServices;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell;
+
+[Guid(""bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5"")]
+public class ToolWindow1 : ToolWindowPane
+{
+    public ToolWindow1() : base(null)
+    {
+        this.Caption = ""ToolWindow1"";
+        this.Content = new UserControl();
+    }
+
+    public ToolWindow1(string message)
+        : this()
+    {
+    }
+}
+";
+
+        this.VerifyCSharpDiagnostic(new[] { package, toolWindow });
+    }
+
+    [Fact]
+    public void RTWCompatibleAsyncToolWindow_ProducesNoDiagnostic()
+    {
+        var package = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+[ProvideToolWindow(typeof(ToolWindow1))]
+class ToolWindow1Package : AsyncPackage
+    , IVsAsyncToolWindowFactory
+    , IVsAsyncToolWindowFactoryProvider
+{
+    IVsTask IVsAsyncToolWindowFactory.InitializeToolWindowAsync(Guid guid, uint id)
+    {
+        IVsTask task = this.JoinableTaskFactory.RunAsyncAsVsTask(
+            VsTaskRunContext.UIThreadBackgroundPriority,
+            async (cancellationToken) => await InitializeToolWindowAsync(typeof(ToolWindow1), (int)id, cancellationToken));
+
+        return task;
+    }
+
+    void IVsAsyncToolWindowFactory.CreateToolWindow(Guid guid, uint id, object context)
+    {
+    }
+
+    string IVsAsyncToolWindowFactory.GetToolWindowTitle(Guid guid, uint id)
+    {
+        throw new NotImplementedException();
+    }
+
+    async Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
+    {
+        await Task.Delay(5000, cancellationToken);
+
+        return ""foo"";
+    }
+}
+";
+        var toolWindow = @"
+using System.Runtime.InteropServices;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell;
+
+[Guid(""bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5"")]
+public class ToolWindow1 : ToolWindowPane
+{
+    public ToolWindow1() : base(null)
+    {
+        this.Caption = ""ToolWindow1"";
+        this.Content = new UserControl();
+    }
+
+    public ToolWindow1(string message)
+        : this()
+    {
+    }
+}
+";
+
+        this.VerifyCSharpDiagnostic(new[] { package, toolWindow });
+    }
+
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK003SupportAsyncToolWindowAnalyzer();
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -32,6 +32,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             internal const string GetServiceAsync = "GetServiceAsync";
 
             /// <summary>
+            /// The name of the GetAsyncToolWindowFactory method.
+            /// </summary>
+            internal const string GetAsyncToolWindowFactory = "GetAsyncToolWindowFactory";
+
+            /// <summary>
             /// Gets an array of the nesting namespaces for this type.
             /// </summary>
             internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
@@ -225,6 +230,32 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// Gets the name of the <see cref="Shell.PackageRegistrationAttribute.AllowsBackgroundLoading"/> property.
             /// </summary>
             internal const string AllowsBackgroundLoading = nameof(Shell.PackageRegistrationAttribute.AllowsBackgroundLoading);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.ProvideToolWindowAttribute"/> type.
+        /// </summary>
+        internal static class ProvideToolWindowAttribute
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.ProvideToolWindowAttribute"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.ProvideToolWindowAttribute);
 
             /// <summary>
             /// Gets an array of the nesting namespaces for this type.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK003SupportAsyncToolWindowAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK003SupportAsyncToolWindowAnalyzer.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.Shell;
+
+    /// <summary>
+    /// Identifies cases where a <see cref="ToolWindowPane" /> is proffered by a VS package without supporting asynchronous initialization.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class VSSDK003SupportAsyncToolWindowAnalyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+        /// </summary>
+        public const string Id = "VSSDK003";
+
+        /// <summary>
+        /// A reusable descriptor for diagnostics produced by this analyzer.
+        /// </summary>
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: "Support async tool windows",
+            messageFormat: "Tool windows should support async construction",
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Performance",
+            defaultSeverity: DiagnosticSeverity.Info,
+            isEnabledByDefault: true);
+
+        /// <summary>
+        /// A cached array for the <see cref="SupportedDiagnostics"/> property.
+        /// </summary>
+        private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDiagnostics = ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDiagnostics;
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            // Register for compilation first so that we only activate the analyzer for applicable compilations
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                var asyncPackageType = compilationContext.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName)?.OriginalDefinition;
+                var provideToolWindowAttribute = compilationContext.Compilation.GetTypeByMetadataName(Types.ProvideToolWindowAttribute.FullName)?.OriginalDefinition;
+                bool targetVSSupportsAsyncToolWindows = asyncPackageType?.MemberNames.Any(n => n == Types.AsyncPackage.GetAsyncToolWindowFactory) ?? false;
+                if (targetVSSupportsAsyncToolWindows)
+                {
+                    // Reuse the type symbols we looked up so that we don't have to look them up for every single class declaration.
+                    compilationContext.RegisterSyntaxNodeAction(
+                        Utils.DebuggableWrapper(ctxt => this.AnalyzeClassDeclaration(ctxt, asyncPackageType, provideToolWindowAttribute)),
+                        SyntaxKind.ClassDeclaration);
+                }
+            });
+        }
+
+        private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol asyncPackageType, INamedTypeSymbol provideToolWindowAttributeType)
+        {
+            var declaration = (ClassDeclarationSyntax)context.Node;
+            var baseType = declaration.BaseList?.Types.FirstOrDefault();
+            if (baseType == null)
+            {
+                return;
+            }
+
+            var baseTypeSymbol = context.SemanticModel.GetSymbolInfo(baseType.Type, context.CancellationToken).Symbol?.OriginalDefinition as ITypeSymbol;
+
+            if (!Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, asyncPackageType))
+            {
+                return;
+            }
+
+            var userClassSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+            var packageRegistrationInstance = userClassSymbol?.GetAttributes().FirstOrDefault(a => a.AttributeClass?.Equals(provideToolWindowAttributeType) ?? false);
+            var firstParameter = packageRegistrationInstance?.ConstructorArguments.FirstOrDefault();
+            if (firstParameter.Value.Kind == TypedConstantKind.Type && firstParameter.Value.Value is INamedTypeSymbol typeOfUserToolWindow)
+            {
+                bool toolWindowHasCtorWithOneParameter = typeOfUserToolWindow.GetMembers(ConstructorInfo.ConstructorName).OfType<IMethodSymbol>().Any(c => c.Parameters.Length == 1);
+                if (!toolWindowHasCtorWithOneParameter)
+                {
+                    if (packageRegistrationInstance.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is AttributeSyntax attributeSyntax)
+                    {
+                        AttributeArgumentSyntax firstArgumentSyntax = attributeSyntax.ArgumentList.Arguments.First();
+                        Location diagnosticLocation = firstArgumentSyntax.GetLocation();
+                        if (firstArgumentSyntax.Expression is TypeOfExpressionSyntax typeOfArg)
+                        {
+                            diagnosticLocation = typeOfArg.Type.GetLocation();
+                        }
+
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, diagnosticLocation));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -7,5 +7,6 @@
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="vs-devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" protocolVersion="3" />
+    <add key="vs-sdk" value="https://vside.myget.org/F/vssdk/api/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
# VSSDK003 Support async tool windows

Offer an async tool window factory for your tool windows so Visual Studio startup
is fast if the tool window is initially visible, and remains responsive when your
tool window is activated later in the session.

This analyzer only flags synchronous tool windows when proffered from an `AsyncPackage`-derived
VS package and when targeting Visual Studio 2017 Update 6 or later.

## Examples of patterns that are flagged by this analyzer

```csharp
[Guid("bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5")]
public class ToolWindow1 : ToolWindowPane
{
    public ToolWindow1() : base(null)
    {
        this.Caption = "ToolWindow1";
        this.Content = new ToolWindow1Control();
    }
}

public class ToolWindow1Package : AsyncPackage
{
    // A lack of async tool window factory overrides
}
```

## Solution

Override the async tool window factory methods on your `AsyncPackage`-derived class
and offer a constructor overload in your `ToolWindowPane`-derived class that accepts one parameter.

```csharp
[Guid("bd7b3e0c-f79e-46c1-8a04-12cbb8161ce5")]
public class ToolWindow1 : ToolWindowPane
{
    public ToolWindow1() : base(null)
    {
        this.Caption = "ToolWindow1";
        this.Content = new ToolWindow1Control();
    }

    public ToolWindow1(string message)
        : this()
    {
    }
}

public class ToolWindow1Package : AsyncPackage
{
    public override IVsAsyncToolWindowFactory GetAsyncToolWindowFactory(Guid toolWindowType)
    {
        if (toolWindowType == typeof(ToolWindow1).GUID)
        {
            return this;
        }

        return base.GetAsyncToolWindowFactory(toolWindowType);
    }

    protected override string GetToolWindowTitle(Type toolWindowType, int id)
    {
        if (toolWindowType == typeof(ToolWindow1))
        {
            return "ToolWindow1 loading";
        }

        return base.GetToolWindowTitle(toolWindowType, id);
    }

    protected override async Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
    {
        // potentially expensive work, preferably done on a background thread where possible.
        await Task.Delay(5000, cancellationToken);

        return "foo"; // this is passed to the tool window constructor
    }
}
```

Closes #21 