### PR TITLE
Create VSSDK004 analyzer to warn about using synchronous auto load

### DIFF
--- a/doc/VSSDK004.md
+++ b/doc/VSSDK004.md
@@ -1,0 +1,43 @@
+# VSSDK004 Use BackgroundLoad flag in ProvideAutoLoad attribute for asynchronous auto load
+
+In order to provide performance guarentees in critical scenarios such as startup and solution load,
+Visual Studio will deprecate synchronous auto load requests in a future version.
+
+This analyzer flags all use of ProvideAutoLoad attributes that doesn't provide BackgroundLoad flag or
+SkipWhenUIContextRulesActive flag where latter tells Visual Studio versions supporting AsyncPackage to
+ignore auto load request.
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+[ProvideAutoLoad("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}")]
+[PackageRegistration(UseManagedResourcesOnly = true)]
+class MyCoolPackage : Package {
+    protected override void Initialize()
+    {
+        base.Initialize();
+    }
+}
+```
+
+## Solution
+
+Provide BackgroundLoad flag in your ProvideAutoLoad and also derive from AsyncPackage as needed.
+
+```csharp
+[ProvideAutoLoad("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", PackageAutoLoadFlags.BackgroundLoad)]
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class MyCoolPackage : AsyncPackage {
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await base.InitializeAsync(cancellationToken, progress);
+
+        // When initialized asynchronously, we *may* be on a background thread at this point.
+        // Do any initialization that requires the UI thread after switching to the UI thread.
+        // Otherwise, remove the switch to the UI thread if you don't need it.
+        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+    }
+}
+```
+
+For more information, please see https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-use-asyncpackage-to-load-vspackages-in-the-background

--- a/doc/index.md
+++ b/doc/index.md
@@ -8,5 +8,6 @@ ID | Title | Category
 [VSSDK001](VSSDK001.md) | Derive from AsyncPackage | Performance
 [VSSDK002](VSSDK002.md) | PackageRegistration matches Package | Performance
 [VSSDK003](VSSDK003.md) | Support async tool windows | Performance
+[VSSDK004](VSSDK004.md) | Use BackgroundLoad flag in ProvideAutoLoad attribute | Performance
 
 [1]: https://nuget.org/packages/microsoft.visualstudio.sdk.analyzers

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
 
         private static readonly ImmutableArray<string> VSSDKPackageReferences = ImmutableArray.Create(new string[]
         {
-            Path.Combine("Microsoft.VisualStudio.OLE.Interop", "7.10.6071", "lib", "Microsoft.VisualStudio.OLE.Interop.dll"),
+            Path.Combine("Microsoft.VisualStudio.OLE.Interop", "7.10.6071", "lib\\net11", "Microsoft.VisualStudio.OLE.Interop.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Interop", "7.10.6072", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Interop.8.0", "8.0.50728", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.8.0.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Interop.9.0", "9.0.30730", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.9.0.dll"),
@@ -169,6 +169,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
                 Environment.GetEnvironmentVariable("USERPROFILE"),
                 ".nuget",
                 "packages");
+            nugetPackageRoot = @"e:\nuget\packages";
             var vssdkReferences = VSSDKPackageReferences.Select(e =>
                 MetadataReference.CreateFromFile(Path.Combine(nugetPackageRoot, e)));
             solution = solution.AddMetadataReferences(projectId, vssdkReferences);

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -169,7 +169,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
                 Environment.GetEnvironmentVariable("USERPROFILE"),
                 ".nuget",
                 "packages");
-
             var vssdkReferences = VSSDKPackageReferences.Select(e =>
                 MetadataReference.CreateFromFile(Path.Combine(nugetPackageRoot, e)));
             solution = solution.AddMetadataReferences(projectId, vssdkReferences);

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
 
         private static readonly ImmutableArray<string> VSSDKPackageReferences = ImmutableArray.Create(new string[]
         {
-            Path.Combine("Microsoft.VisualStudio.OLE.Interop", "7.10.6071", "lib\\net11", "Microsoft.VisualStudio.OLE.Interop.dll"),
+            Path.Combine("Microsoft.VisualStudio.OLE.Interop", "7.10.6071", "lib", "Microsoft.VisualStudio.OLE.Interop.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Interop", "7.10.6072", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Interop.8.0", "8.0.50728", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.8.0.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Interop.9.0", "9.0.30730", "lib\\net11", "Microsoft.VisualStudio.Shell.Interop.9.0.dll"),
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
                 Environment.GetEnvironmentVariable("USERPROFILE"),
                 ".nuget",
                 "packages");
-            nugetPackageRoot = @"e:\nuget\packages";
+
             var vssdkReferences = VSSDKPackageReferences.Select(e =>
                 MetadataReference.CreateFromFile(Path.Combine(nugetPackageRoot, e)));
             solution = solution.AddMetadataReferences(projectId, vssdkReferences);

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
@@ -14,7 +14,7 @@ public class VSSDK004ProvideAutoLoadAttributeAnalyzerTests : DiagnosticVerifier
     {
         Id = VSSDK004ProvideAutoLoadAttributeAnalyzer.Id,
         SkipVerifyMessage = true,
-        Severity = DiagnosticSeverity.Info,
+        Severity = DiagnosticSeverity.Warning,
     };
 
     public VSSDK004ProvideAutoLoadAttributeAnalyzerTests(ITestOutputHelper logger)

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
@@ -63,6 +63,38 @@ class Test : AsyncPackage {
     }
 
     [Fact]
+    public void MultipleProvideAutoLoadProducesMultipleDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{A184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.None)]
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.None)]
+class Test : AsyncPackage {
+}
+";
+        DiagnosticResult[] expected = new[]
+        {
+            new DiagnosticResult()
+            {
+                Id = VSSDK004ProvideAutoLoadAttributeAnalyzer.Id,
+                SkipVerifyMessage = true,
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 2, 4, 86) },
+            },
+            new DiagnosticResult()
+            {
+                Id = VSSDK004ProvideAutoLoadAttributeAnalyzer.Id,
+                SkipVerifyMessage = true,
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 2, 5, 86) },
+            },
+        };
+
+        this.VerifyCSharpDiagnostic(test, expected);
+    }
+
+    [Fact]
     public void ProvideAutoLoadWithNamedFlagsButNoBackgroundLoadProducesDiagnostics()
     {
         var test = @"

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.SDK.Analyzers;
+using Microsoft.VisualStudio.SDK.Analyzers.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+public class VSSDK004ProvideAutoLoadAttributeAnalyzerTests : DiagnosticVerifier
+{
+    private DiagnosticResult expect = new DiagnosticResult
+    {
+        Id = VSSDK004ProvideAutoLoadAttributeAnalyzer.Id,
+        SkipVerifyMessage = true,
+        Severity = DiagnosticSeverity.Info,
+    };
+
+    public VSSDK004ProvideAutoLoadAttributeAnalyzerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void NoProvideAutoLoadProducesNoDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+class Test : AsyncPackage {
+}
+";
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void BasicProvideAutoLoadProducesDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
+class Test : AsyncPackage {
+}
+";
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 2, 4, 59) };
+        this.VerifyCSharpDiagnostic(test, this.expect);
+    }
+
+    [Fact]
+    public void ProvideAutoLoadWithFlagsButNoBackgroundLoadProducesDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.None)]
+class Test : AsyncPackage {
+}
+";
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 2, 4, 86) };
+        this.VerifyCSharpDiagnostic(test, this.expect);
+    }
+
+    [Fact]
+    public void ProvideAutoLoadWithNamedFlagsButNoBackgroundLoadProducesDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", flags: PackageAutoLoadFlags.None)]
+class Test : AsyncPackage {
+}
+";
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 2, 4, 93) };
+        this.VerifyCSharpDiagnostic(test, this.expect);
+    }
+
+    [Fact]
+    public void ProvideAutoLoadWithSkipFlagProducesNoDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.SkipWhenUIContextRulesActive)]
+class Test : AsyncPackage {
+}
+";
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void ProvideAutoLoadWithBackgroundLoadFlagProducesNoDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
+class Test : AsyncPackage {
+}
+";
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void ProvideAutoLoadOnPackageWithBackgroundLoadFlagProducesNoDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
+class Test : Package {
+}
+";
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK004ProvideAutoLoadAttributeAnalyzer();
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
@@ -23,6 +23,19 @@ public class VSSDK004ProvideAutoLoadAttributeAnalyzerTests : DiagnosticVerifier
     }
 
     [Fact]
+    public void NoPackageBaseClassProvidesNoDiagnostics()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
+class Test {
+}
+";
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
     public void NoProvideAutoLoadProducesNoDiagnostics()
     {
         var test = @"
@@ -115,7 +128,7 @@ class Test : AsyncPackage {
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.SkipWhenUIContextRulesActive)]
-class Test : AsyncPackage {
+class Test : Package {
 }
 ";
         this.VerifyCSharpDiagnostic(test);
@@ -135,7 +148,7 @@ class Test : AsyncPackage {
     }
 
     [Fact]
-    public void ProvideAutoLoadOnPackageWithBackgroundLoadFlagProducesNoDiagnostics()
+    public void ProvideAutoLoadOnPackageWithBackgroundLoadFlagProducesDiagnostics()
     {
         var test = @"
 using Microsoft.VisualStudio.Shell;
@@ -144,7 +157,8 @@ using Microsoft.VisualStudio.Shell;
 class Test : Package {
 }
 ";
-        this.VerifyCSharpDiagnostic(test);
+        this.expect.Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 2, 4, 96) };
+        this.VerifyCSharpDiagnostic(test, this.expect);
     }
 
     protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK004ProvideAutoLoadAttributeAnalyzer();

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -324,6 +324,5 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// </summary>
             internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
         }
-
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -315,6 +315,27 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
 
             /// <summary>
+            /// Copy of auto load flag values from <see cref="Shell.PackageAutoLoadFlags"/>
+            /// </summary>
+            internal enum Values
+            {
+                /// <summary>
+                /// Indicates synchronous load in all versions of Visual Studio
+                /// </summary>
+                None = 0,
+
+                /// <summary>
+                /// Indicates auto load request should be ignored when Visual Studio has UIContextRules feature
+                /// </summary>
+                SkipWhenUIContextRulesActive = 1,
+
+                /// <summary>
+                /// Indicates auto load should be requested asynchronously
+                /// </summary>
+                BackgroundLoad = 2,
+            }
+
+            /// <summary>
             /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
             /// </summary>
             internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -272,5 +272,58 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// </summary>
             internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
         }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.ProvideAutoLoadAttribute"/> type.
+        /// </summary>
+        internal static class ProvideAutoLoadAttribute
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.ProvideAutoLoadAttribute"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.ProvideAutoLoadAttribute);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Shell.PackageAutoLoadFlags"/> type.
+        /// </summary>
+        internal static class PackageAutoLoadFlags
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Shell.PackageAutoLoadFlags"/> type.
+            /// </summary>
+            internal const string TypeName = nameof(Shell.PackageAutoLoadFlags);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
+            /// </summary>
+            internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+        }
+
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         /// </summary>
         internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
             id: Id,
-            title: "Auto loads without background load option will be deprecated in future updates.",
+            title: "Use BackgroundLoad flag in ProvideAutoLoad attribute for asynchronous auto load.",
             messageFormat: "Synchronous auto loads will be deprecated in future versions, consider using BackgroundLoad flag and AsyncPackage base class.",
             helpLinkUri: Utils.GetHelpLink(Id),
             category: "Usage",

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             title: "Use BackgroundLoad flag in ProvideAutoLoad attribute for asynchronous auto load.",
             messageFormat: "Synchronous auto loads will be deprecated in future versions, consider using BackgroundLoad flag and AsyncPackage base class.",
             helpLinkUri: Utils.GetHelpLink(Id),
-            category: "Usage",
+            category: "Performance",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
@@ -45,6 +45,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             // Register for compilation first so that we only activate the analyzer for applicable compilations
             context.RegisterCompilationStartAction(compilationContext =>
             {
+                var package = compilationContext.Compilation.GetTypeByMetadataName(Types.Package.FullName);
                 var asyncPackage = compilationContext.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName);
                 if (asyncPackage != null)
                 {
@@ -52,15 +53,30 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                     var packageAutoLoadFlags = compilationContext.Compilation.GetTypeByMetadataName(Types.PackageAutoLoadFlags.FullName);
 
                     // Reuse the type symbols we looked up so that we don't have to look them up for every single class declaration.
-                    compilationContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(ctxt => this.AnalyzeClassDeclaration(ctxt, autoLoadAttribute, packageAutoLoadFlags)), SyntaxKind.ClassDeclaration);
+                    compilationContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(ctxt => this.AnalyzeClassDeclaration(ctxt, autoLoadAttribute, packageAutoLoadFlags, package, asyncPackage)), SyntaxKind.ClassDeclaration);
                 }
             });
         }
 
-        private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol autoLoadAttributeType, INamedTypeSymbol packageAutoLoadFlagsType)
+        private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol autoLoadAttributeType, INamedTypeSymbol packageAutoLoadFlagsType, INamedTypeSymbol packageType, INamedTypeSymbol asyncPackageType)
         {
             var declaration = (ClassDeclarationSyntax)context.Node;
             var userClassSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+
+            var baseType = declaration.BaseList?.Types.FirstOrDefault();
+            if (baseType == null)
+            {
+                return;
+            }
+
+            // Don't evaluate if base type is not Package
+            var baseTypeSymbol = context.SemanticModel.GetSymbolInfo(baseType.Type, context.CancellationToken).Symbol?.OriginalDefinition as ITypeSymbol;
+            if (!Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, packageType))
+            {
+                return;
+            }
+
+            bool isBaseTypeAsyncPackage = Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, asyncPackageType);
 
             // Enumerate all attribute lists and attribute to find ProvideAutoLoad attributes as there can be multiple ones
             foreach (var autoLoadInstance in userClassSymbol?.GetAttributes().Where(a => a.AttributeClass == autoLoadAttributeType))
@@ -68,9 +84,14 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                 var flagsArgument = autoLoadInstance.ConstructorArguments.FirstOrDefault(p => p.Type == packageAutoLoadFlagsType);
                 Types.PackageAutoLoadFlags.Values flagsValue = flagsArgument.IsNull ? Types.PackageAutoLoadFlags.Values.None : (Types.PackageAutoLoadFlags.Values)flagsArgument.Value;
 
-                // We are looking for any auto load attribute without the BackgroundLoad flag and SkipWhenUIContextRulesActive flag.
-                if (!flagsValue.HasFlag(Types.PackageAutoLoadFlags.Values.BackgroundLoad) &&
-                    !flagsValue.HasFlag(Types.PackageAutoLoadFlags.Values.SkipWhenUIContextRulesActive))
+                // Check if AutoLoad attribute applies to VS versions with AsyncPackage support
+                if (flagsValue.HasFlag(Types.PackageAutoLoadFlags.Values.SkipWhenUIContextRulesActive))
+                {
+                    continue;
+                }
+
+                // Check if BackgroundLoad flag is present and base class is AsyncPackage
+                if (!(flagsValue.HasFlag(Types.PackageAutoLoadFlags.Values.BackgroundLoad) && isBaseTypeAsyncPackage))
                 {
                     var attributeSyntax = autoLoadInstance.ApplicationSyntaxReference.GetSyntax(context.CancellationToken) as AttributeSyntax;
                     Location location = attributeSyntax.GetLocation();

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.Shell;
+
+    /// <summary>
+    /// Discovers VS packages that derive directly from <see cref="Package"/> instead of <see cref="AsyncPackage"/>.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class VSSDK004ProvideAutoLoadAttributeAnalyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+        /// </summary>
+        public const string Id = "VSSDK004";
+
+        /// <summary>
+        /// A reusable descriptor for diagnostics produced by this analyzer.
+        /// </summary>
+        internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: Id,
+            title: "Auto loads without background load option will be deprecated in future updates.",
+            messageFormat: "Synchronous auto loads not using BackgroundLoad option paired with AsyncPackage implementations will be deprecated in future updates.",
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            // Register for compilation first so that we only activate the analyzer for applicable compilations
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                var asyncPackage = compilationContext.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName);
+                if (asyncPackage != null)
+                {
+                    var autoLoadAttribute = compilationContext.Compilation.GetTypeByMetadataName(Types.ProvideAutoLoadAttribute.FullName);
+                    var packageAutoLoadFlags = compilationContext.Compilation.GetTypeByMetadataName(Types.PackageAutoLoadFlags.FullName);
+
+                    // Reuse the type symbols we looked up so that we don't have to look them up for every single class declaration.
+                    compilationContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(ctxt => this.AnalyzeClassDeclaration(ctxt, autoLoadAttribute, packageAutoLoadFlags)), SyntaxKind.ClassDeclaration);
+                }
+            });
+        }
+
+        private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol autoLoadAttributeType, INamedTypeSymbol packageAutoLoadFlagsType)
+        {
+            var declaration = (ClassDeclarationSyntax)context.Node;
+            var userClassSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+
+            // Enumerate all attribute lists and attribute to find ProvideAutoLoad attributes as there can be multiple ones
+            foreach (var autoLoadInstance in userClassSymbol?.GetAttributes().Where(a => a.AttributeClass == autoLoadAttributeType))
+            {
+                var flagsArgument = autoLoadInstance.ConstructorArguments.FirstOrDefault(p => p.Type == packageAutoLoadFlagsType);
+                Shell.PackageAutoLoadFlags flagsValue = flagsArgument.IsNull ? PackageAutoLoadFlags.None : (Shell.PackageAutoLoadFlags)flagsArgument.Value;
+
+                // We are looking for any auto load attribute without the BackgroundLoad flag and SkipWhenUIContextRulesActive flag.
+                if (!flagsValue.HasFlag(Shell.PackageAutoLoadFlags.BackgroundLoad) &&
+                    !flagsValue.HasFlag(Shell.PackageAutoLoadFlags.SkipWhenUIContextRulesActive))
+                {
+                    var attributeSyntax = autoLoadInstance.ApplicationSyntaxReference.GetSyntax(context.CancellationToken) as AttributeSyntax;
+                    Location location = attributeSyntax.GetLocation();
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, attributeSyntax.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
-    /// Discovers <see cref="ProvideAutoLoadAttribute"/> usages without BackgroundLoad flag.
+    /// Discovers <see cref="Microsoft.VisualStudio.Shell.ProvideAutoLoadAttribute"/> usages without BackgroundLoad flag.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class VSSDK004ProvideAutoLoadAttributeAnalyzer : DiagnosticAnalyzer

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         internal static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
             id: Id,
             title: "Auto loads without background load option will be deprecated in future updates.",
-            messageFormat: "Synchronous auto loads not using BackgroundLoad option paired with AsyncPackage implementations will be deprecated in future updates.",
+            messageFormat: "Synchronous auto loads will be deprecated in future versions, consider using BackgroundLoad flag and AsyncPackage base class.",
             helpLinkUri: Utils.GetHelpLink(Id),
             category: "Usage",
             defaultSeverity: DiagnosticSeverity.Warning,

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -9,7 +9,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.VisualStudio.Shell;
 
     /// <summary>
     /// Discovers <see cref="ProvideAutoLoadAttribute"/> usages without BackgroundLoad flag.
@@ -67,11 +66,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             foreach (var autoLoadInstance in userClassSymbol?.GetAttributes().Where(a => a.AttributeClass == autoLoadAttributeType))
             {
                 var flagsArgument = autoLoadInstance.ConstructorArguments.FirstOrDefault(p => p.Type == packageAutoLoadFlagsType);
-                Shell.PackageAutoLoadFlags flagsValue = flagsArgument.IsNull ? PackageAutoLoadFlags.None : (Shell.PackageAutoLoadFlags)flagsArgument.Value;
+                Types.PackageAutoLoadFlags.Values flagsValue = flagsArgument.IsNull ? Types.PackageAutoLoadFlags.Values.None : (Types.PackageAutoLoadFlags.Values)flagsArgument.Value;
 
                 // We are looking for any auto load attribute without the BackgroundLoad flag and SkipWhenUIContextRulesActive flag.
-                if (!flagsValue.HasFlag(Shell.PackageAutoLoadFlags.BackgroundLoad) &&
-                    !flagsValue.HasFlag(Shell.PackageAutoLoadFlags.SkipWhenUIContextRulesActive))
+                if (!flagsValue.HasFlag(Types.PackageAutoLoadFlags.Values.BackgroundLoad) &&
+                    !flagsValue.HasFlag(Types.PackageAutoLoadFlags.Values.SkipWhenUIContextRulesActive))
                 {
                     var attributeSyntax = autoLoadInstance.ApplicationSyntaxReference.GetSyntax(context.CancellationToken) as AttributeSyntax;
                     Location location = attributeSyntax.GetLocation();

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK004ProvideAutoLoadAttributeAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
     using Microsoft.VisualStudio.Shell;
 
     /// <summary>
-    /// Discovers VS packages that derive directly from <see cref="Package"/> instead of <see cref="AsyncPackage"/>.
+    /// Discovers <see cref="ProvideAutoLoadAttribute"/> usages without BackgroundLoad flag.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class VSSDK004ProvideAutoLoadAttributeAnalyzer : DiagnosticAnalyzer


### PR DESCRIPTION
Adds a new analyzer that raises a warning for every ProvideAutoLoad request that doesn't use BackgroundLoad flag or SkipWhenRuleBasedUIContext flag.