### PR TITLE
Allow tests to be tolerant of alternate globalPackagesFolder locations

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -165,10 +165,13 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
                 }
             }
 
-            string nugetPackageRoot = Path.Combine(
-                Environment.GetEnvironmentVariable("USERPROFILE"),
-                ".nuget",
-                "packages");
+            string globalPackagesFolder = Environment.GetEnvironmentVariable("globalPackagesFolder");
+            string nugetPackageRoot = string.IsNullOrEmpty(globalPackagesFolder)
+                ? Path.Combine(
+                    Environment.GetEnvironmentVariable("USERPROFILE"),
+                    ".nuget",
+                    "packages")
+                : globalPackagesFolder;
             var vssdkReferences = VSSDKPackageReferences.Select(e =>
                 MetadataReference.CreateFromFile(Path.Combine(nugetPackageRoot, e)));
             solution = solution.AddMetadataReferences(projectId, vssdkReferences);

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
                 }
             }
 
-            string globalPackagesFolder = Environment.GetEnvironmentVariable("globalPackagesFolder");
+            string globalPackagesFolder = Environment.GetEnvironmentVariable("NuGetGlobalPackagesFolder");
             string nugetPackageRoot = string.IsNullOrEmpty(globalPackagesFolder)
                 ? Path.Combine(
                     Environment.GetEnvironmentVariable("USERPROFILE"),


### PR DESCRIPTION
This doesn't make it work automatically, but it allows the user who has redirected the default nuget cache path to another location to set a user environment variable to that same path so that it always works on that machine.

Fixes #18 