### PR TITLE
Bump master branch to represent v15.8 version

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "15.6-beta",
+  "version": "15.8-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches


### PR DESCRIPTION
We now have a v15.6 branch that will continue to track that release.

I need a v15.8 branch to track the vs-threading analyzer changes which I'll send a PR for once this PR is accepted.