### PR TITLE
Add AdditionalFiles for vs-threading analyzers

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.MainThreadAssertingMethods.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.MainThreadAssertingMethods.txt
@@ -1,0 +1,1 @@
+Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.TypesRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.TypesRequiringMainThread.txt
@@ -1,0 +1,4 @@
+Microsoft.VisualStudio.Shell.Interop.*
+Microsoft.VisualStudio.OLE.Interop.*
+Microsoft.Internal.VisualStudio.Shell.Interop.*
+!Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/Microsoft.VisualStudio.SDK.Analyzers.targets
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/Microsoft.VisualStudio.SDK.Analyzers.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)AdditionalFiles\**" Visible="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This is the alternative to #10 

When the first vs-threading 15.8 package is pushed to a nuget feed, we can update our dependency in the master branch to point at it.