### PR TITLE
Fix InvalidOperationException thrown from VSSDK003

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK003SupportAsyncToolWindowAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK003SupportAsyncToolWindowAnalyzerTests.cs
@@ -216,5 +216,16 @@ public class ToolWindow1 : ToolWindowPane
         this.VerifyCSharpDiagnostic(new[] { package, toolWindow });
     }
 
+    [Fact]
+    public void NoPackageAttributes()
+    {
+        var package = @"
+public class ProtocolPackage : Microsoft.VisualStudio.Shell.AsyncPackage
+{
+}
+    ";
+        this.VerifyCSharpDiagnostic(package);
+    }
+
     protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VSSDK003SupportAsyncToolWindowAnalyzer();
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK003SupportAsyncToolWindowAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK003SupportAsyncToolWindowAnalyzer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             var userClassSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
             var packageRegistrationInstance = userClassSymbol?.GetAttributes().FirstOrDefault(a => a.AttributeClass?.Equals(provideToolWindowAttributeType) ?? false);
             var firstParameter = packageRegistrationInstance?.ConstructorArguments.FirstOrDefault();
-            if (firstParameter.Value.Kind == TypedConstantKind.Type && firstParameter.Value.Value is INamedTypeSymbol typeOfUserToolWindow)
+            if (firstParameter.HasValue && firstParameter.Value.Kind == TypedConstantKind.Type && firstParameter.Value.Value is INamedTypeSymbol typeOfUserToolWindow)
             {
                 bool toolWindowHasCtorWithOneParameter = typeOfUserToolWindow.GetMembers(ConstructorInfo.ConstructorName).OfType<IMethodSymbol>().Any(c => c.Parameters.Length == 1);
                 if (!toolWindowHasCtorWithOneParameter)


### PR DESCRIPTION
When a Package class doesn't apply ProvideToolWindowAttribute, we didn't handle it well.

Fixes #44