### PR TITLE
Consume vs-threading 15.8.46-beta

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,10 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Avoid using MSBuild properties as macros for PackageReference/@Version
-         due to issue https://github.com/dotnet/project-system/issues/2129 -->
     <PackageReference Include="GitLink" Version="3.2.0-unstable0018" PrivateAssets="all" />
-    <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.54" PrivateAssets="all" />
+    <PackageReference Include="MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" PrivateAssets="all" />
     <PackageReference Include="StreamJsonRpc" Version="1.3.23" PrivateAssets="all" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,11 +27,11 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.6.27415" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0" Version="14.3.26929" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.6.46" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.46-beta" PrivateAssets="all" />
 
     <!-- We WANT these analyzers to be expressed as dependencies of the final package. -->
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.6.46" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.46-beta" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/DiagnosticVerifier.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers.Tests
             Path.Combine("Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime", "15.6.27415", "lib\\net20", "Microsoft.VisualStudio.Shell.Interop.15.6.DesignTime.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.15.0", "15.6.27415", "lib\\net45", "Microsoft.VisualStudio.Shell.15.0.dll"),
             Path.Combine("Microsoft.VisualStudio.Shell.Framework", "15.6.27415", "lib\\net45", "Microsoft.VisualStudio.Shell.Framework.dll"),
-            Path.Combine("Microsoft.VisualStudio.Threading", "15.6.46", "lib\\net45", "Microsoft.VisualStudio.Threading.dll"),
+            Path.Combine("Microsoft.VisualStudio.Threading", "15.8.46-beta", "lib\\net45", "Microsoft.VisualStudio.Threading.dll"),
         });
 
         private static string csharpDefaultFileExt = "cs";

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.MainThreadAssertingMethods.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.MainThreadAssertingMethods.txt
@@ -1,1 +1,1 @@
-Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread
+[Microsoft.VisualStudio.Shell.ThreadHelper]::ThrowIfNotOnUIThread

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.TypesRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.TypesRequiringMainThread.txt
@@ -1,5 +1,7 @@
-Microsoft.VisualStudio.Shell.ServiceProvider
-Microsoft.VisualStudio.Shell.Interop.*
-Microsoft.VisualStudio.OLE.Interop.*
-Microsoft.Internal.VisualStudio.Shell.Interop.*
-!Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider
+[Microsoft.VisualStudio.Shell.ServiceProvider]
+[Microsoft.VisualStudio.Shell.Interop.*]
+[Microsoft.VisualStudio.OLE.Interop.*]
+[Microsoft.Internal.VisualStudio.Shell.Interop.*]
+![Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider]
+[Microsoft.VisualStudio.Shell.Package]::GetService
+[Microsoft.VisualStudio.Shell.ServiceProvider]

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.TypesRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.TypesRequiringMainThread.txt
@@ -1,3 +1,4 @@
+Microsoft.VisualStudio.Shell.ServiceProvider
 Microsoft.VisualStudio.Shell.Interop.*
 Microsoft.VisualStudio.OLE.Interop.*
 Microsoft.Internal.VisualStudio.Shell.Interop.*


### PR DESCRIPTION
This updates the dependency from the 15.6 era of vs-threading analyzers to 15.8, with it, the `AdditionalFiles` actually become active.

I'm preparing a change for the VS repo's 15.8 branch to consume vs-threading 15.8, so it will need vssdk-analyzers 15.8 to be installed as well so that the analyzers keep checking for UI thread requirements.