### PR TITLE
Remove AsyncUsageAnalyzers dependency

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.6.56" PrivateAssets="all" />
 
     <!-- We WANT these analyzers to be expressed as dependencies of the final package. -->
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="none" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.6.56" PrivateAssets="none" />
   </ItemGroup>
 


### PR DESCRIPTION
It's an unstable package, so our stable one shouldn't depend on it.