### PR TITLE
Fix analyzer package dependencies on non-net46 target frameworks

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1-beta1-62706-01" PrivateAssets="all" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="PackBuildOutputs" BeforeTargets="_GetPackageFiles" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Microsoft.VisualStudio.SDK.Analyzers.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <CodeAnalysisRuleSet>Microsoft.VisualStudio.SDK.Analyzers.ruleset</CodeAnalysisRuleSet>
+    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8;net46</PackageTargetFallback>
 
     <PackageTags>analyzers visualstudio vssdk sdk</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -307,7 +307,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the simple name of the <see cref="Shell.PackageAutoLoadFlags"/> type.
             /// </summary>
-            internal const string TypeName = nameof(Shell.PackageAutoLoadFlags);
+            internal const string TypeName = "PackageAutoLoadFlags";
 
             /// <summary>
             /// Gets an array of the nesting namespaces for this type.


### PR DESCRIPTION
NuGet doesn't support package dependencies spanning more target frameworks than the project file being built. This means that although vssdk-analyzers can be installed in a netstandard-targeting project, the vs-threading analyzers will be left out. 

This works around that limitation, and gets these analyzers working on `dotnet build` as well, by targeting .netstandard1.1 for the analyzers themselves.

We do reference net46 assemblies (the VS SDK itself) from the analyzers _project_, but that's just so we can use `nameof` referring to VS SDK types. These references are dropped from the compiled assembly (and we have a test to verify this). So I don't feel _too_ bad about adding net46 and a `PackageTargetFallback`.

@sharwell may be interested in this (at least to 😲 gasp at the hack)