### PR TITLE
Fix NRE thrown from VSSDK006 for projects that don't reference the VS SDK

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/MultiAnalyzerTests.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/MultiAnalyzerTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.SDK.Analyzers;
+using Microsoft.VisualStudio.SDK.Analyzers.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+public class MultiAnalyzerTests : DiagnosticVerifier
+{
+    public MultiAnalyzerTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void BasicPackage()
+    {
+        var test = @"
+using System;
+using System.Threading;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+class Test : AsyncPackage {
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress) {
+        await base.InitializeAsync(cancellationToken, progress);
+    }
+}
+";
+
+        this.VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void NoVSSDK()
+    {
+        var test = @"
+using System;
+using System.Threading;
+
+class Test {
+}
+";
+
+        this.VerifyCSharpDiagnostic(test, vssdk: false);
+    }
+
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => throw new NotImplementedException();
+
+    protected override ImmutableArray<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+    {
+        IEnumerable<DiagnosticAnalyzer> analyzers = from type in typeof(VSSDK001DeriveFromAsyncPackageAnalyzer).Assembly.GetTypes()
+                                                    where type.GetCustomAttributes(typeof(DiagnosticAnalyzerAttribute), true).Any()
+                                                    select (DiagnosticAnalyzer)Activator.CreateInstance(type);
+        return analyzers.ToImmutableArray();
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
@@ -49,11 +49,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                         start.Compilation.GetTypeByMetadataName(Types.Package.FullName)?.GetMembers(Types.Package.GetService),
                         start.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName)?.GetMembers(Types.AsyncPackage.GetServiceAsync),
                         start.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName)?.GetMembers(Types.Package.GetService),
-                        start.Compilation.GetTypeByMetadataName(Types.ServiceProvider.FullName).GetMembers(Types.ServiceProvider.GetService),
-                        start.Compilation.GetTypeByMetadataName(Types.IServiceProvider.FullName).GetMembers(Types.IServiceProvider.GetService),
-                        start.Compilation.GetTypeByMetadataName(Types.IAsyncServiceProvider.FullName).GetMembers(Types.IAsyncServiceProvider.GetServiceAsync)),
+                        start.Compilation.GetTypeByMetadataName(Types.ServiceProvider.FullName)?.GetMembers(Types.ServiceProvider.GetService),
+                        start.Compilation.GetTypeByMetadataName(Types.IServiceProvider.FullName)?.GetMembers(Types.IServiceProvider.GetService),
+                        start.Compilation.GetTypeByMetadataName(Types.IAsyncServiceProvider.FullName)?.GetMembers(Types.IAsyncServiceProvider.GetServiceAsync)),
                     Flatten(
-                        start.Compilation.GetTypeByMetadataName(Types.Assumes.FullName).GetMembers(Types.Assumes.Present)));
+                        start.Compilation.GetTypeByMetadataName(Types.Assumes.FullName)?.GetMembers(Types.Assumes.Present)));
                 if (state.ShouldAnalyze)
                 {
                     start.RegisterSyntaxNodeAction(state.AnalyzeInvocationExpression, SyntaxKind.InvocationExpression);


### PR DESCRIPTION
The VSSDK006 analyzer assumed that VS SDK assemblies were referenced.

With this change, it correctly no-opts when the VS SDK is not referenced.
I also add a test that covers *all* VSSDK analyzers simulating a project without these reference assemblies to verify this bug doesn't exist anywhere else nor will regress.