### PR TITLE
Consider GetGlobalServiceAsync to be free-threaded

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
@@ -1,8 +1,8 @@
+![Microsoft.VisualStudio.Shell.ServiceProvider]::GetGlobalServiceAsync
 [Microsoft.VisualStudio.Shell.ServiceProvider]
 [Microsoft.VisualStudio.Shell.Interop.*]
 [Microsoft.VisualStudio.OLE.Interop.*]
 [Microsoft.Internal.VisualStudio.Shell.Interop.*]
 ![Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider]
 [Microsoft.VisualStudio.Shell.Package]::GetService
-[Microsoft.VisualStudio.Shell.ServiceProvider]
 [EnvDTE.*]


### PR DESCRIPTION
Also get rid of redundant `Shell.ServiceProvider` line.

Fixes #82 