### PR TITLE
Set UIContext.IsActive as a thread affinitized property

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
@@ -19,3 +19,4 @@
 ![Microsoft.VisualStudio.Shell.Interop.IVsAppContainerProjectDeployOperation]
 ![Microsoft.VisualStudio.Shell.Interop.IVsAppContainerProjectDeployResult]
 ![Microsoft.VisualStudio.Shell.Interop.SVsAppContainerProjectDeploy]
+[Microsoft.VisualStudio.Shell.UIContext]::IsActive


### PR DESCRIPTION
Technically the property *getter* is free-threaded, but the setter is not and we can only set thread affinity per property rather than per property accessor.

See https://github.com/microsoft/vs-threading/issues/540 which tracks improving this.