### PR TITLE
Strong name sign our assemblies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <MicroBuildVersion>2.0.58</MicroBuildVersion>
-    <MicroBuild_DoNotStrongNameSign>true</MicroBuild_DoNotStrongNameSign>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)PackageIcon.png" Pack="true" PackagePath="" />

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/app.config
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.Tests/app.config
@@ -1,0 +1,5 @@
+<configuration>
+  <appSettings>
+    <add key="xunit.shadowCopy" value="false"/>
+  </appSettings>
+</configuration>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Microsoft.VisualStudio.SDK.Analyzers.CodeFixes")]
+[assembly: InternalsVisibleTo("Microsoft.VisualStudio.SDK.Analyzers.CodeFixes, PublicKey=" + ThisAssembly.PublicKey)]


### PR DESCRIPTION
This is crucial to allow desktop CLR to load multiple versions of the assembly side-by-side and thereby avoid the TypeInitializationException thrown from the code fix assembly.

Fixes #105