### PR TITLE
Stop building empty snupkg packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,8 +22,6 @@
     <PackageIcon>PackageIcon.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <MicroBuildVersion>2.0.58</MicroBuildVersion>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.csproj
@@ -35,8 +35,9 @@
   <Target Name="PackBuildOutputs" BeforeTargets="_GetPackageFiles" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">
     <ItemGroup>
       <Content Include="$(TargetDir)Microsoft.VisualStudio.SDK.Analyzers.dll" Pack="true" PackagePath="analyzers\cs\" />
+      <Content Include="$(TargetDir)Microsoft.VisualStudio.SDK.Analyzers.pdb" Pack="true" PackagePath="analyzers\cs\" />
       <Content Include="$(TargetPath)" Pack="true" PackagePath="analyzers\cs\" />
-      <!--<Content Include="@(DebugSymbolsProjectOutputGroupOutput)" Pack="true" PackagePath="analyzers\cs\" />-->
+      <Content Include="@(DebugSymbolsProjectOutputGroupOutput)" Pack="true" PackagePath="analyzers\cs\" />
       <Content Include="@(SatelliteDllsProjectOutputGroupOutput)" Pack="true" PackagePath="analyzers\cs\%(SatelliteDllsProjectOutputGroupOutput.Culture)\" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Put pdb files in the primary .nupkg instead, since when running analyzers, the package will always be around anyway.