### PR TITLE
VSSDK003 improvements for Community.VisualStudio.Toolkit style of tool windows

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK003SupportAsyncToolWindowAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK003SupportAsyncToolWindowAnalyzer.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             if (firstParameter.HasValue && firstParameter.Value.Kind == TypedConstantKind.Type && firstParameter.Value.Value is INamedTypeSymbol typeOfUserToolWindow)
             {
                 // If the tool window has a constructor that takes a parameter,
-                // then the tool window is probably created asynchronously, because you 
+                // then the tool window is probably created asynchronously, because you
                 // cannot easily pass a parameter when creating a synchronous tool window.
                 bool toolWindowHasCtorWithOneParameter = typeOfUserToolWindow.GetMembers(ConstructorInfo.ConstructorName).OfType<IMethodSymbol>().Any(c => c.Parameters.Length == 1);
                 if (toolWindowHasCtorWithOneParameter)


### PR DESCRIPTION
Fixes #72 

I've added an additional case to check for when determining if a tool window is probably created asynchronously. If the `AsyncPackage.GetAsyncToolWindowFactory` method is overridden, then it assumes the tool window will be created asynchronously. That's not an absolute guarantee, but I think it's reasonable to assume that if the `GetAsyncToolWindowFactory` method has been overridden, then any tool windows in the package will be handled via that method, which means they will be created asynchronously. 