### PR TITLE
VSSDK007 ThreadHelper.JoinableTaskFactory.RunAsync

### DIFF
--- a/doc/VSSDK007.md
+++ b/doc/VSSDK007.md
@@ -1,8 +1,15 @@
 # VSSDK007 Avoid ThreadHelper for fire and forget tasks
 
-Tasks created from `ThreadHelper.JoinableTaskFactory.RunAsync` must be awaited or joined.
+A `JoinableTask` created from `ThreadHelper.JoinableTaskFactory.RunAsync` must be awaited or joined.
 
-The `JoinableTaskFactory` instance on [`Microsoft.VisualStudio.Shell.ThreadHelper`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.threadhelper?view=visualstudiosdk-2019) is unsuitable for fire and forget tasks. Prefer the `JoinableTaskFactory` instance on `AsyncPackage` or, when a package is unavailable (e.g. MEF), consider [implementing](https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#void-returning-fire-and-forget-methods) your own equivalent like [`Community.VisualStudio.Toolkit.ToolkitThreadHelper`](https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/blob/master/src/Community.VisualStudio.Toolkit.Shared/ToolkitThreadHelper.cs).
+The `JoinableTaskFactory` instance on [`Microsoft.VisualStudio.Shell.ThreadHelper`][ThreadHelper] produces `JoinableTask`s that do not block exiting the IDE, and is therefore unsuitable for fire and forget tasks that need to complete or cancel before shutdown.
+
+All async work should be tracked so that exiting the IDE waits for the task to complete.
+Normally this is done by `await`ing the work directly where it is called.
+
+When using `JoinableTaskFactory.RunAsync` where awaiting the result is not an option,
+the easiest way to ensure shutdown is blocked till the task completes is to use the `JoinableTaskFactory` instance on `AsyncPackage`.
+Alternatively, when a package is unavailable (e.g. when implementing a MEF part), consider using the [`Community.VisualStudio.Toolkit.ToolkitThreadHelper`][ToolkitThreadHelper] or [implementing your own][FireAndForget] to track the async work and block a `Dispose` method till the work is done.
 
 ## Examples of patterns that are flagged by this analyzer
 
@@ -11,33 +18,33 @@ class MyCoolPackage : AsyncPackage
 {
     public void StartOperation1()
     {
-		ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
-		{
-			// Some work where we don't care about its result/completion
-			await Task.Delay(100);
-		});
+        ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
+        {
+            // Some work where we don't care about its result/completion
+            await Task.Delay(100);
+        });
     }
-	
-	public void StartOperation2()
+
+    public void StartOperation2()
     {
-		ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
-		{
-			// Some work where we don't care about its result/completion
-			await Task.Delay(100);
-		}).Task.Forget();
-		
-		// Note: Extension methods like Task.Forget and FileAndForget do not make ThreadHelper safe for fire and forget
+        ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
+        {
+            // Some work where we don't care about its result/completion
+            await Task.Delay(100);
+        }).Task.Forget();
+
+        // Note: Extension methods like Task.Forget and FileAndForget do not make ThreadHelper safe for fire and forget
     }
-	
-	public void StartOperation3()
+
+    public void StartOperation3()
     {
-		var task = ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
-		{
-			// Some work where we don't care about its result/completion
-			await Task.Delay(100);
-		});
-		
-		// Note: task is not awaited/joined
+        var task = ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
+        {
+            // Some work where we don't care about its result/completion
+            await Task.Delay(100);
+        });
+
+        // Note: task is not awaited/joined
     }
 }
 ```
@@ -53,33 +60,33 @@ class MyCoolPackage : AsyncPackage
 {
     public void StartOperation1()
     {
-		this.JoinableTaskFactory.RunAsync(async delegate
-		{
-			// Some work where we don't care about its result/completion
-			await Task.Delay(100);
-		});
-		
-		// Note: Prefer an extension method like Task.Forget to signal that the task is fire and forget
+        this.JoinableTaskFactory.RunAsync(async delegate
+        {
+            // Some work where we don't care about its result/completion
+            await Task.Delay(100);
+        });
+
+        // Note: Prefer an extension method like Task.Forget to signal that the task is fire and forget
     }
-	
-	public void StartOperation2()
+
+    public void StartOperation2()
     {
-		this.JoinableTaskFactory.RunAsync(async delegate
-		{
-			// Some work where we don't care about its result/completion
-			await Task.Delay(100);
-		}).Task.Forget();
+        this.JoinableTaskFactory.RunAsync(async delegate
+        {
+            // Some work where we don't care about its result/completion
+            await Task.Delay(100);
+        }).Task.Forget();
     }
-	
-	public void StartOperation3()
+
+    public void StartOperation3()
     {
-		var task = this.JoinableTaskFactory.RunAsync(async delegate
-		{
-			// Some work where we don't care about its result/completion
-			await Task.Delay(100);
-		});
-		
-		// Note: Prefer an extension method like Task.Forget to signal that the task is fire and forget
+        var task = this.JoinableTaskFactory.RunAsync(async delegate
+        {
+            // Some work where we don't care about its result/completion
+            await Task.Delay(100);
+        });
+
+        // Note: Prefer an extension method like Task.Forget to signal that the task is fire and forget
     }
 }
 ```
@@ -93,29 +100,33 @@ class MyCoolPackage : AsyncPackage
 {
     public void PerformOperation()
     {
-		ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
-		{
-			await Task.Delay(100);
-		}).Join();  // We meant to wait for the result or completion
-		
-		// Or even better:
-		ThreadHelper.JoinableTaskFactory.Run(async delegate
-		{
-			await Task.Delay(100);
-		});
+        ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+        {
+            await Task.Delay(100);
+        }).Join();  // We meant to synchronously block for the result or completion
+
+        // Or more simply:
+        ThreadHelper.JoinableTaskFactory.Run(async delegate
+        {
+            await Task.Delay(100);
+        });
     }
-	
-	public async Task PerformOperationAsync()
+
+    public async Task PerformOperationAsync()
     {
-		var task = ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
-		{
-			await Task.Delay(100);
-		});
-		
-		// Perhaps something else here
-	
-		// We meant to wait for the result or completion
-		await task;  // or task.Join()
+        var task = ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+        {
+            await Task.Delay(100);
+        });
+
+        // Perhaps something else here
+
+        // We meant to await for the result or completion
+        await task; // or task.Join() to block synchronously if not in an async method.
     }
 }
 ```
+
+[ThreadHelper]: https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.threadhelper?view=visualstudiosdk-2019
+[ToolkitThreadHelper]: https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/blob/22c9362197c29b7282075c3a7550d0445fbb313a/src/Community.VisualStudio.Toolkit.Shared/Helpers/ToolkitThreadHelper.cs#L68
+[FireAndForget]: https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#void-returning-fire-and-forget-methods

--- a/doc/VSSDK007.md
+++ b/doc/VSSDK007.md
@@ -1,0 +1,121 @@
+# VSSDK007 Avoid ThreadHelper for fire and forget tasks
+
+Tasks created from `ThreadHelper.JoinableTaskFactory.RunAsync` must be awaited or joined.
+
+The `JoinableTaskFactory` instance on [`Microsoft.VisualStudio.Shell.ThreadHelper`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.threadhelper?view=visualstudiosdk-2019) is unsuitable for fire and forget tasks. Prefer the `JoinableTaskFactory` instance on `AsyncPackage` or, when a package is unavailable (e.g. MEF), consider [implementing](https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#void-returning-fire-and-forget-methods) your own equivalent like [`Community.VisualStudio.Toolkit.ToolkitThreadHelper`](https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/blob/master/src/Community.VisualStudio.Toolkit.Shared/ToolkitThreadHelper.cs).
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+class MyCoolPackage : AsyncPackage
+{
+    public void StartOperation1()
+    {
+		ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
+		{
+			// Some work where we don't care about its result/completion
+			await Task.Delay(100);
+		});
+    }
+	
+	public void StartOperation2()
+    {
+		ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
+		{
+			// Some work where we don't care about its result/completion
+			await Task.Delay(100);
+		}).Task.Forget();
+		
+		// Note: Extension methods like Task.Forget and FileAndForget do not make ThreadHelper safe for fire and forget
+    }
+	
+	public void StartOperation3()
+    {
+		var task = ThreadHelper.JoinableTaskFactory.RunAsync(async delegate   // warning reported here
+		{
+			// Some work where we don't care about its result/completion
+			await Task.Delay(100);
+		});
+		
+		// Note: task is not awaited/joined
+    }
+}
+```
+
+## Solution
+
+### Fire and forget
+
+If you want to call `RunAsync` without awaiting it, use the `JoinableTaskFactory` instance from `AsyncPackage` (or an alternative as described above).
+
+```csharp
+class MyCoolPackage : AsyncPackage
+{
+    public void StartOperation1()
+    {
+		this.JoinableTaskFactory.RunAsync(async delegate
+		{
+			// Some work where we don't care about its result/completion
+			await Task.Delay(100);
+		});
+		
+		// Note: Prefer an extension method like Task.Forget to signal that the task is fire and forget
+    }
+	
+	public void StartOperation2()
+    {
+		this.JoinableTaskFactory.RunAsync(async delegate
+		{
+			// Some work where we don't care about its result/completion
+			await Task.Delay(100);
+		}).Task.Forget();
+    }
+	
+	public void StartOperation3()
+    {
+		var task = this.JoinableTaskFactory.RunAsync(async delegate
+		{
+			// Some work where we don't care about its result/completion
+			await Task.Delay(100);
+		});
+		
+		// Note: Prefer an extension method like Task.Forget to signal that the task is fire and forget
+    }
+}
+```
+
+### Await or join
+
+If you didn't intend to use `ThreadHelper.JoinableTaskFactory.RunAsync` in a fire and forget fashion then its result must be awaited or joined.
+
+```csharp
+class MyCoolPackage : AsyncPackage
+{
+    public void PerformOperation()
+    {
+		ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+		{
+			await Task.Delay(100);
+		}).Join();  // We meant to wait for the result or completion
+		
+		// Or even better:
+		ThreadHelper.JoinableTaskFactory.Run(async delegate
+		{
+			await Task.Delay(100);
+		});
+    }
+	
+	public async Task PerformOperationAsync()
+    {
+		var task = ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+		{
+			await Task.Delay(100);
+		});
+		
+		// Perhaps something else here
+	
+		// We meant to wait for the result or completion
+		await task;  // or task.Join()
+    }
+}
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -11,6 +11,7 @@ ID | Title | Category
 [VSSDK004](VSSDK004.md) | Use BackgroundLoad flag in ProvideAutoLoad attribute | Performance
 [VSSDK005](VSSDK005.md) | Use the JoinableTaskContext singleton | Reliability
 [VSSDK006](VSSDK006.md) | Check service exists | Reliability
+[VSSDK007](VSSDK007.md) | Avoid ThreadHelper for fire and forget tasks | Reliability
 
 This analyzer package also depends on the [Microsoft.VisualStudio.Threading.Analyzers][2] package, which adds [many more analyzers][3].
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,4 @@ VSSDK003 | Performance | Info | VSSDK003SupportAsyncToolWindowAnalyzer
 VSSDK004 | Performance | Warning | VSSDK004ProvideAutoLoadAttributeAnalyzer
 VSSDK005 | Reliability | Error | VSSDK005UseJoinableTaskContextSingletonAnalyzer
 VSSDK006 | Reliability | Warning | VSSDK006CheckServicesExistAnalyzer
+VSSDK007 | Reliability | Warning | VSSDK007ThreadHelperJTFRunAsync

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -340,6 +340,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
             /// </summary>
             internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -374,9 +379,45 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         internal static class JoinableTaskFactory
         {
             /// <summary>
+            /// Gets the simple name of the <see cref="Threading.JoinableTaskFactory"/> type.
+            /// </summary>
+            internal const string TypeName = "JoinableTaskFactory";
+
+            /// <summary>
             /// The name of the <see cref="JoinableTaskFactory.SwitchToMainThreadAsync"/> method.
             /// </summary>
             internal const string SwitchToMainThreadAsync = nameof(JoinableTaskFactory.SwitchToMainThreadAsync);
+
+            /// <summary>
+            /// The name of the <see cref="JoinableTaskFactory.RunAsync"/> method.
+            /// </summary>
+            internal const string RunAsync = "RunAsync";
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioThreading;
+        }
+
+        /// <summary>
+        /// Describes the <see cref="Threading.JoinableTask"/> type.
+        /// </summary>
+        internal static class JoinableTask
+        {
+            /// <summary>
+            /// Gets the simple name of the <see cref="Threading.JoinableTask"/> type.
+            /// </summary>
+            internal const string TypeName = "JoinableTask";
+
+            /// <summary>
+            /// The name of the <see cref="Threading.JoinableTask.Join"/> method.
+            /// </summary>
+            internal const string Join = "Join";
+
+            /// <summary>
+            /// The name of the <see cref="Threading.JoinableTask.JoinAsync"/> method.
+            /// </summary>
+            internal const string JoinAsync = "JoinAsync";
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -271,7 +271,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -370,7 +370,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -497,7 +497,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -549,7 +549,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
 
         /// <summary>
@@ -596,7 +596,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.
             /// </summary>
-            internal static string FullName => string.Join(".", Namespace) + "." + TypeName;
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK007ThreadHelperJTFRunAsync.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK007ThreadHelperJTFRunAsync.cs
@@ -1,0 +1,406 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.VisualStudio.SDK.Analyzers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.Shell;
+
+    /// <summary>
+    /// Tasks created from <see cref="ThreadHelper.JoinableTaskFactory"/> must be awaited or joined.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class VSSDK007ThreadHelperJTFRunAsync : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+        /// </summary>
+        public const string Id = "VSSDK007";
+
+        /// <summary>
+        /// A reusable descriptor for diagnostics produced by this analyzer.
+        /// </summary>
+        internal static readonly DiagnosticDescriptor Descriptor = new(
+            id: Id,
+            title: "ThreadHelper.JoinableTaskFactory.RunAsync",
+            messageFormat: "Await/join tasks created from ThreadHelper.JoinableTaskFactory.RunAsync.",
+            description: "ThreadHelper.JoinableTaskFactory.RunAsync is not safe to use for fire-and-forget tasks inside Visual Studio. Either await/join the JoinableTask, or use the JoinableTaskFactory instance from AsyncPackage or ToolkitThreadHelper.",
+            helpLinkUri: Utils.GetHelpLink(Id),
+            category: "Reliability",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <summary>
+        /// A cached array for the <see cref="SupportedDiagnostics"/> property.
+        /// </summary>
+        private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDiagnostics = ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDiagnostics;
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+            // Register for compilation first so that we only activate the analyzer for applicable compilations
+            context.RegisterCompilationStartAction(compilationContext =>
+            {
+                compilationContext.RegisterSyntaxNodeAction(Utils.DebuggableWrapper(ctxt => AnalyzeInvocationExpression(ctxt)), SyntaxKind.InvocationExpression);
+            });
+        }
+
+        private static void AnalyzeInvocationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var invocationExpr = (InvocationExpressionSyntax)context.Node;
+
+            // We don't care about awaited calls.
+            if (IsAwaited(invocationExpr))
+            {
+                return;
+            }
+
+            // Is a member named `RunAsync` being invoked? (Confirm it's the right one later.)
+            if (invocationExpr.Expression is not MemberAccessExpressionSyntax runAsyncExpr ||
+                runAsyncExpr.Name.Identifier.ToString() != Types.JoinableTaskFactory.RunAsync)
+            {
+                return;
+            }
+
+            // Do we have a `JoinableTaskFactory.RunAsync` expression?
+            if (runAsyncExpr.Expression is not MemberAccessExpressionSyntax jtfExpr ||
+                jtfExpr.Name.Identifier.ToString() != Types.JoinableTaskFactory.TypeName)
+            {
+                return;
+            }
+
+            // Do we have a `ThreadHelper.JoinableTaskFactory.RunAsync` expression?
+            if (jtfExpr.Expression is not IdentifierNameSyntax threadHelperExpr ||
+                threadHelperExpr.ToString() != Types.ThreadHelper.TypeName)
+            {
+                return;
+            }
+
+            // Verify `ThreadHelper` is the correct type in the expected namespace.
+            ISymbol? threadHelperSymbol = context
+                .SemanticModel
+                .GetSymbolInfo(threadHelperExpr, context.CancellationToken)
+                .Symbol;
+
+            if (threadHelperSymbol == null || !threadHelperSymbol.BelongsToNamespace(Types.ThreadHelper.Namespace))
+            {
+                return;
+            }
+
+            // Get the symbol for the `RunAsync` method and verify it belongs to the correct JoinableTaskFactory
+            // class in the expected namespace.
+            var isRunAsyncMethodOnJTF =
+                context
+                .SemanticModel
+                .GetSymbolInfo(invocationExpr, context.CancellationToken)
+                .Symbol is IMethodSymbol runAsyncSymbol &&
+                runAsyncSymbol.Name == Types.JoinableTaskFactory.RunAsync &&
+                runAsyncSymbol.ContainingType.Name == Types.JoinableTaskFactory.TypeName &&
+                runAsyncSymbol.ContainingType.BelongsToNamespace(Types.JoinableTaskFactory.Namespace);
+
+            if (!isRunAsyncMethodOnJTF)
+            {
+                return;
+            }
+
+            // No diagnostic if the RunAsync invocation is immediately synchronously joined with Join(),
+            // e.g.  ThreadHelper.JoinableTaskFactory.RunAsync(...).Join();
+            if (IsSynchronouslyJoined(context, invocationExpr))
+            {
+                return;
+            }
+
+            // Is the JoinableTask returned from RunAsync assigned to a variable? If so, search the enclosing block
+            // and check if that variable is awaited/joined.
+            if (IsJoinableTaskAssigned(invocationExpr, out SyntaxNode? assignedTo, out SyntaxToken? assignedToToken) &&
+                assignedTo != null &&
+                assignedToToken != null)
+            {
+                SyntaxNode? enclosingBlock = GetEnclosingBlock(assignedTo);
+                if (enclosingBlock != null)
+                {
+                    if (IsVariableAwaitedOrJoined(context, assignedToToken.Value.ValueText, enclosingBlock))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            // Report the diagnostic
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, runAsyncExpr.Name.GetLocation()));
+        }
+
+        /// <summary>
+        /// Determines whether the given invocation expression is part of an await expression.
+        /// </summary>
+        private static bool IsAwaited(InvocationExpressionSyntax invocationExpr)
+        {
+            AwaitExpressionSyntax? foundAwait = Utils.FindAncestor<AwaitExpressionSyntax>(
+                invocationExpr,
+                n => n is MemberAccessExpressionSyntax || n is InvocationExpressionSyntax,
+                (aes, child) => aes.Expression == child);
+
+            return foundAwait != null;
+        }
+
+        /// <summary>
+        /// Determines whether the given invocation expression includes a <see cref="Threading.JoinableTask.Join"/> method.
+        /// </summary>
+        private static bool IsSynchronouslyJoined(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpr)
+        {
+            if (invocationExpr.Parent == null ||
+                invocationExpr.Parent is not MemberAccessExpressionSyntax ||
+                context.SemanticModel.GetSymbolInfo(invocationExpr.Parent, context.CancellationToken).Symbol is not IMethodSymbol methodSymbol ||
+                methodSymbol.Name != Types.JoinableTask.Join)
+            {
+                return false;
+            }
+
+            return
+                methodSymbol.ContainingType.Name == Types.JoinableTask.TypeName &&
+                methodSymbol.ContainingType.BelongsToNamespace(Types.JoinableTaskFactory.Namespace);
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="Threading.JoinableTask"/> returned from the RunAsync invocation is assigned to a variable, and if so
+        /// returns the variable's syntax node and identifier token.
+        /// </summary>
+        private static bool IsJoinableTaskAssigned(InvocationExpressionSyntax invocationExpr, out SyntaxNode? assignedToNode, out SyntaxToken? assignedToToken)
+        {
+            if (invocationExpr.Parent == null)
+            {
+                assignedToNode = null;
+                assignedToToken = null;
+                return false;
+            }
+
+            // Look for assignment to existing variable/field:  myVarOrField = ThreadHelper.JoinableTaskFactory.RunAsync(...)
+            if (invocationExpr.Parent.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                var assignmentExpr = (AssignmentExpressionSyntax)invocationExpr.Parent;
+                assignedToNode = assignmentExpr.Left;
+                assignedToToken = ((IdentifierNameSyntax)assignedToNode).Identifier;
+                return true;
+            }
+
+            // Look for assignment to new variable:  var myTask = ThreadHelper.JoinableTaskFactory.RunAsync(...)
+            SyntaxNode node = invocationExpr.Parent;
+            while (node != null)
+            {
+                if (node.IsKind(SyntaxKind.VariableDeclarator))
+                {
+                    assignedToNode = node;
+                    assignedToToken = ((VariableDeclaratorSyntax)assignedToNode).Identifier;
+                    return true;
+                }
+
+                node = node.Parent;
+            }
+
+            assignedToNode = null;
+            assignedToToken = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Return the enclosing scope block that contains the given node.
+        /// </summary>
+        private static SyntaxNode? GetEnclosingBlock(SyntaxNode node)
+        {
+            while (node != null)
+            {
+                if (node.IsKind(SyntaxKind.Block))
+                {
+                    return node;
+                }
+
+                node = node.Parent;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determine whether the given variable is awaited or joined within the specified scope block.
+        /// </summary>
+        private static bool IsVariableAwaitedOrJoined(SyntaxNodeAnalysisContext context, string variableName, SyntaxNode enclosingBlock)
+        {
+            // No diagnostic for:  await task;
+            IEnumerable<AwaitExpressionSyntax>? awaitedList = from awaitExpr in enclosingBlock.DescendantNodes().OfType<AwaitExpressionSyntax>()
+                              where awaitExpr.ChildNodes().OfType<IdentifierNameSyntax>().Count() == 1 &&
+                                    awaitExpr.ChildNodes().OfType<IdentifierNameSyntax>().Single().Identifier.ValueText == variableName
+                              select awaitExpr;
+
+            if (awaitedList.Any())
+            {
+                return true;
+            }
+
+            // No diagnostic for:  task.Join();
+            IEnumerable<IdentifierNameSyntax>? methodCallList = from varMethodCall in enclosingBlock.DescendantNodes().OfType<MemberAccessExpressionSyntax>()
+                                 where varMethodCall.ChildNodes().OfType<IdentifierNameSyntax>().Count() == 2 &&
+                                       varMethodCall.ChildNodes().OfType<IdentifierNameSyntax>().First().Identifier.ValueText == variableName
+                                 select varMethodCall.ChildNodes().OfType<IdentifierNameSyntax>().ElementAt(1);
+
+            foreach (IdentifierNameSyntax? method in methodCallList)
+            {
+                if (method.Identifier.ValueText == Types.JoinableTask.Join)
+                {
+                    return true;
+                }
+            }
+
+            // No diagnostic for:  await task.JoinAsync();
+            IEnumerable<AwaitExpressionSyntax>? awaitedJoinAsyncList = from awaitExpr in enclosingBlock.DescendantNodes().OfType<AwaitExpressionSyntax>()
+                                       where VariableAwaitsJoinAsyncMethod(variableName, awaitExpr)
+                                       select awaitExpr;
+
+            if (awaitedJoinAsyncList.Any())
+            {
+                return true;
+            }
+
+            // Find any methods that the JoinableTask variable is passed to in case any of these methods performs the join,
+            // and recursively search them to determine if they perform the await/join.
+            IEnumerable<InvocationExpressionSyntax>? passedToMethodList = enclosingBlock.DescendantNodes().OfType<InvocationExpressionSyntax>();
+            foreach (InvocationExpressionSyntax? passedToMethodInvocation in passedToMethodList)
+            {
+                if (VariablePassedAsArgumentToInvokedMethod(variableName, passedToMethodInvocation, out IdentifierNameSyntax? methodName, out var argIndex) &&
+                    methodName != null &&
+                    argIndex != null)
+                {
+                    if (context.SemanticModel.GetSymbolInfo(methodName, context.CancellationToken).Symbol is not IMethodSymbol methodSymbol)
+                    {
+                        return false;
+                    }
+
+                    if (argIndex < methodSymbol.Parameters.Length)
+                    {
+                        IParameterSymbol? param = methodSymbol.Parameters[argIndex.Value];
+                        SyntaxNode? methodEnclosingBlock = GetMethodDeclarationBlockNode(methodSymbol);
+                        if (methodEnclosingBlock == null)
+                        {
+                            return false;
+                        }
+
+                        // Is the parameter awaited/joined inside the method?
+                        if (IsVariableAwaitedOrJoined(context, param.Name, methodEnclosingBlock))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determine whether the given variable calls the <see cref="Threading.JoinableTask.JoinAsync"/> method in an await expression.
+        /// </summary>
+        private static bool VariableAwaitsJoinAsyncMethod(string variableName, AwaitExpressionSyntax awaitExpr)
+        {
+            if (string.IsNullOrEmpty(variableName))
+            {
+                return false;
+            }
+
+            IEnumerable<MemberAccessExpressionSyntax>? memberAccessList = awaitExpr.DescendantNodes().OfType<MemberAccessExpressionSyntax>();
+            if (memberAccessList.Count() != 1)
+            {
+                return false;
+            }
+
+            MemberAccessExpressionSyntax? memberAccess = memberAccessList.First();
+
+            IEnumerable<IdentifierNameSyntax>? childIdentifiers = memberAccess.ChildNodes().OfType<IdentifierNameSyntax>();
+            if (!childIdentifiers.Any())
+            {
+                return false;
+            }
+
+            if (childIdentifiers.First().Identifier.ValueText != variableName)
+            {
+                return false;
+            }
+
+            return childIdentifiers.ElementAt(1).Identifier.ValueText == Types.JoinableTask.JoinAsync;
+        }
+
+        /// <summary>
+        /// Determine whether the given variable is passed as an argument to an invoked method, and if so return the
+        /// method name and the zero-based index of the argument.
+        /// </summary>
+        private static bool VariablePassedAsArgumentToInvokedMethod(
+            string variableName,
+            InvocationExpressionSyntax invocationExpr,
+            out IdentifierNameSyntax? methodName,
+            out int? argumentIndex)
+        {
+            if (string.IsNullOrEmpty(variableName))
+            {
+                methodName = null;
+                argumentIndex = 0;
+                return false;
+            }
+
+            ArgumentListSyntax? argList = invocationExpr.ChildNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
+            if (argList == null)
+            {
+                methodName = null;
+                argumentIndex = 0;
+                return false;
+            }
+
+            var index = 0;
+            foreach (ArgumentSyntax? arg in argList.ChildNodes().OfType<ArgumentSyntax>())
+            {
+                foreach (IdentifierNameSyntax? identiferName in arg.ChildNodes().OfType<IdentifierNameSyntax>())
+                {
+                    if (identiferName.Identifier.ValueText == variableName)
+                    {
+                        methodName = invocationExpr.ChildNodes().OfType<IdentifierNameSyntax>().FirstOrDefault();
+                        argumentIndex = index;
+                        return true;
+                    }
+                }
+
+                ++index;
+            }
+
+            methodName = null;
+            argumentIndex = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Get the method declaration node for the given method symbol.
+        /// </summary>
+        private static SyntaxNode? GetMethodDeclarationNode(IMethodSymbol methodSymbol)
+        {
+            SyntaxReference? syntaxReference = methodSymbol.DeclaringSyntaxReferences.FirstOrDefault();
+            return syntaxReference?.GetSyntax();
+        }
+
+        /// <summary>
+        /// Get a method declaration's block node.
+        /// </summary>
+        private static SyntaxNode? GetMethodDeclarationBlockNode(IMethodSymbol methodSymbol)
+        {
+            SyntaxNode? methodDeclNode = GetMethodDeclarationNode(methodSymbol);
+            return methodDeclNode?.ChildNodes().OfType<BlockSyntax>().FirstOrDefault();
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK007ThreadHelperJTFRunAsyncTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK007ThreadHelperJTFRunAsyncTests.cs
@@ -80,36 +80,6 @@ namespace ConsoleApplication1
         await Verify.VerifyAnalyzerAsync(test, expected);
     }
 
-    /*[Fact]
-    public async Task RunAsync_CommunityToolkit_ForgetAndLogOnFailure_Warning()
-    {
-        var src = @"
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
-using Community.VisualStudio.Toolkit;
-namespace ConsoleApplication1
-{
-    class Test
-    {
-        static void Foo()
-        {
-            ThreadHelper.JoinableTaskFactory.{|#0:RunAsync|}(async () =>
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            }).ForgetAndLogOnFailure();
-        }
-    }
-}";
-        Verify.Test test = new()
-        {
-            TestCode = src,
-            IncludeCommunityToolkit = true
-        };
-
-        DiagnosticResult expected = Verify.Diagnostic().WithLocation(0);
-        await Verify.VerifyAnalyzerAsync(test, expected);
-    }*/
-
     [Fact]
     public async Task RunAsync_Awaited_NoWarning()
     {

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK007ThreadHelperJTFRunAsyncTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK007ThreadHelperJTFRunAsyncTests.cs
@@ -1,0 +1,472 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = CSharpCodeFixVerifier<
+    Microsoft.VisualStudio.SDK.Analyzers.VSSDK007ThreadHelperJTFRunAsync,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSSDK007ThreadHelperJTFRunAsyncTests
+{
+    [Fact]
+    public async Task RunAsync_Dropped_Warning()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static void Foo()
+        {
+            ThreadHelper.JoinableTaskFactory.{|#0:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+        }
+    }
+}";
+
+        DiagnosticResult expected = Verify.Diagnostic().WithLocation(0);
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task RunAsync_Forget_Warning()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static void Foo()
+        {
+            ThreadHelper.JoinableTaskFactory.{|#0:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            }).Task.Forget();
+        }
+    }
+}";
+
+        DiagnosticResult expected = Verify.Diagnostic().WithLocation(0);
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task RunAsync_FileAndForget_Warning()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static void Foo()
+        {
+            ThreadHelper.JoinableTaskFactory.{|#0:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            }).FileAndForget(""test"");
+        }
+    }
+}";
+
+        DiagnosticResult expected = Verify.Diagnostic().WithLocation(0);
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    /*[Fact]
+    public async Task RunAsync_CommunityToolkit_ForgetAndLogOnFailure_Warning()
+    {
+        var src = @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Community.VisualStudio.Toolkit;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static void Foo()
+        {
+            ThreadHelper.JoinableTaskFactory.{|#0:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            }).ForgetAndLogOnFailure();
+        }
+    }
+}";
+        Verify.Test test = new()
+        {
+            TestCode = src,
+            IncludeCommunityToolkit = true
+        };
+
+        DiagnosticResult expected = Verify.Diagnostic().WithLocation(0);
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }*/
+
+    [Fact]
+    public async Task RunAsync_Awaited_NoWarning()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static async Task FooAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+        }
+    }
+}";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RunAsync_Joined_NoWarning()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static async Task FooAsync()
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            }).Join();
+        }
+    }
+}";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RunAsync_AssignedButNotJoined_Warning()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        private static JoinableTask _task;
+        static async Task FooAsync()
+        {
+            var task1 = ThreadHelper.JoinableTaskFactory.{|#0:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            JoinableTask task2;
+            task2 = ThreadHelper.JoinableTaskFactory.{|#1:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            var task3 = ThreadHelper.JoinableTaskFactory.{|#2:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            task3.JoinAsync();  // Note: missing await
+            var task4 = ThreadHelper.JoinableTaskFactory.{|#3:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            task4.FileAndForget(""test"");
+            _task = ThreadHelper.JoinableTaskFactory.{|#4:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            var task5 = ThreadHelper.JoinableTaskFactory.{|#5:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            ForwardButNotJoined(task5);
+            var task6 = ThreadHelper.JoinableTaskFactory.{|#6:RunAsync|}(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            OnlyFirstParameterIsJoined(null, task6);
+            ForwardButNotJoined(
+                ThreadHelper.JoinableTaskFactory.{|#7:RunAsync|}(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                }));
+        }
+        static void ForwardButNotJoined(JoinableTask joinableTask)
+        {
+            
+        }
+        static void OnlyFirstParameterIsJoined(JoinableTask jt1, JoinableTask jt2)
+        {
+            jt1.Join();
+        }
+    }
+}";
+
+        DiagnosticResult[] expected = new DiagnosticResult[8]
+        {
+                Verify.Diagnostic().WithLocation(0),
+                Verify.Diagnostic().WithLocation(1),
+                Verify.Diagnostic().WithLocation(2),
+                Verify.Diagnostic().WithLocation(3),
+                Verify.Diagnostic().WithLocation(4),
+                Verify.Diagnostic().WithLocation(5),
+                Verify.Diagnostic().WithLocation(6),
+                Verify.Diagnostic().WithLocation(7),
+        };
+
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task RunAsync_AssignedAndJoined_NoWarning()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static async Task FooAsync()
+        {
+            var task1 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            await task1;
+
+            var task2 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            task2.Join();
+
+            var task3 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            await task3.JoinAsync();
+
+            // Strange but legal:
+            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            }).JoinAsync();
+        }
+    }
+}";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RunAsync_JoinedElsewhere_NoWarning()
+    {
+        var test = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+namespace ConsoleApplication1
+{
+    class Test
+    {
+        static async Task FooAsync()
+        {
+            var task1 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            DoJoin(task1);
+            var task2 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            DoAwait(task2);
+            var task3 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            ForwardAndJoin(task3);
+            var task4 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            ForwardAndAwait(task4);
+            JoinableTask task5;
+            task5 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            DoJoin(task5);
+            var task6 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            await DoAwaitAsync(task6);
+            /*** Test forward and join two tasks. ***/
+            var task7 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            var task8 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            DoJoinTwo(task7, task8);
+            /*** Test argument is tracked to the correct parameter ***/
+            var task9 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>           
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            DoJoinTwo(task9, null);
+            var task10 = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+            DoJoinTwo(null, task10);
+        }
+        static void DoJoin(JoinableTask joinableTask)
+        {
+            joinableTask.Join();
+        }
+        static void DoJoinTwo(JoinableTask jt1, JoinableTask jt2)
+        {
+            if (jt1 != null) jt1.Join();
+            if (jt2 != null) jt2.Join();
+        }
+        static void DoAwait(JoinableTask joinableTask)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await joinableTask;
+            });
+        }
+        static async Task DoAwaitAsync(JoinableTask joinableTask)
+        {
+            await joinableTask;
+        }
+        static void ForwardAndJoin(JoinableTask jt1)
+        {
+            Forward2(jt1);
+        }
+        static void ForwardAndAwait(JoinableTask jt1)
+        {
+            DoAwait(jt1);
+        }
+        static void Forward2(JoinableTask jt2)
+        {
+            Forward3(jt2);
+        }
+        static void Forward3(JoinableTask jt3)
+        {
+            DoJoin(jt3);
+        }
+    }
+}";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RunAsync_Dropped_NotThreadHelper_NoWarning()
+    {
+        var test = @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+namespace ConsoleApplication1
+{
+    class MyThreadHelper
+    {
+        private readonly JoinableTaskContext ctx;
+        private readonly JoinableTaskCollection collection;
+
+        public MyThreadHelper()
+        {
+            ctx = new JoinableTaskContext();
+            collection = ctx.CreateCollection();
+            JoinableTaskFactory = ctx.CreateFactory(collection);
+        }
+
+        public JoinableTaskFactory JoinableTaskFactory { get; }
+    }
+
+    class Test
+    {
+        static void Foo()
+        {
+            MyThreadHelper myHelper = new MyThreadHelper();
+            myHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            });
+        }
+    }
+}";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RunAsync_DifferentType_NoWarning()
+    {
+        var test = @"
+using System.Threading.Tasks;
+namespace ConsoleApplication1
+{
+    class JoinableTaskFactory
+    {
+        public async Task RunAsync()
+        {
+            await Task.Delay(1);
+        }
+    }
+
+    static class ThreadHelper
+    {
+        public static JoinableTaskFactory JoinableTaskFactory { get; set; }
+    }
+
+    class Test
+    {
+        static void Foo()
+        {
+            ThreadHelper.JoinableTaskFactory = new JoinableTaskFactory();
+            ThreadHelper.JoinableTaskFactory.RunAsync();
+
+            var jtf = new JoinableTaskFactory();
+            jtf.RunAsync();
+        }
+    }
+}";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
**Diagnostic message**: Await/join tasks created from ThreadHelper.JoinableTaskFactory.RunAsync.

Adds a new analyzer that detects invocations of `ThreadHelper.JoinableTaskFactory.RunAsync` where the returned `JoinableTask` is never awaited or joined:

- The returned JoinableTask is dropped (either by error or deliberate fire-and-forget without realising the effect of using ThreadHelper's JTF)
- The JoinableTask is assigned to a variable but that variable is never awaited or joined

This is related to #29 but only handles ThreadHelper.JoinableTaskFactory.RunAsync.