### PR TITLE
Remove extraneous StreamJsonRpc dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
-    <PackageReference Include="StreamJsonRpc" Version="2.7.67" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="all" />
 
     <!-- We WANT these analyzers to be expressed as dependencies of the final package. -->

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.9.32" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="16.9.31023.347" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="16.10.0-preview-2-31023-285" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.9.32" PrivateAssets="all" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
This never belonged, but in particular it was causing problems for projects that built with the .NET Core 3.1 SDK, since it updated System.Collections.Immutable from 1.5.0.0 to 5.0.0.0, which .NET Core 3.1 does not include.
