### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://eng.ms/docs/products/dependabot/configuration/version_updates
+
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: /
+  schedule:
+    interval: monthly

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.4",
+      "version": "7.3.5",
       "commands": [
         "pwsh"
       ]
@@ -15,13 +15,13 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.0",
+      "version": "17.7.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.128",
+      "version": "3.6.133",
       "commands": [
         "nbgv"
       ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
 - package-ecosystem: nuget
   directory: /
   schedule:
-    interval: monthly
+    interval: weekly

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <MicroBuildVersion>2.0.117</MicroBuildVersion>
+    <MicroBuildVersion>2.0.130</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.4.0" />
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces" Version="17.6.36236" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.4.33011.337" />
@@ -27,12 +27,12 @@
     <PackageVersion Include="xunit" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.329" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.128" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
   </ItemGroup>
   <ItemGroup>
     <!-- <GlobalPackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" /> -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,6 @@ parameters:
   default: true
 
 variables:
-  MSBuildTreatWarningsAsErrors: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   BuildConfiguration: Release
   # codecov_token: 4dc9e7e2-6b01-4932-a180-847b52b43d35 # Get a new one from https://codecov.io/

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -135,7 +135,7 @@ if (!$Requester) {
         $Requester = $env:USERNAME
     }
     if (!$Requester) {
-        Write-Error "Unable to determine default value for -Requester."
+        $Requester = $OwnerAlias
     }
 }
 
@@ -155,7 +155,7 @@ if (!$RepoUrl) {
 }
 
 Push-Location $PSScriptRoot
-$versionsObj = dotnet tool run nbgv get-version -f json | ConvertFrom-Json
+$versionsObj = dotnet nbgv get-version -f json | ConvertFrom-Json
 Pop-Location
 
 $ReleaseDateString = $ReleaseDate.ToShortDateString()

--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -43,8 +43,13 @@ $PDBs |% {
     }
 } |% {
     # Collect the DLLs/EXEs as well.
-    $dllPath = "$($_.Directory)/$($_.BaseName).dll"
-    $exePath = "$($_.Directory)/$($_.BaseName).exe"
+    $rootName = "$($_.Directory)/$($_.BaseName)"
+    if ($rootName.EndsWith('.ni')) {
+        $rootName = $rootName.Substring(0, $rootName.Length - 3)
+    }
+
+    $dllPath = "$rootName.dll"
+    $exePath = "$rootName.exe"
     if (Test-Path $dllPath) {
         $BinaryImagePath = $dllPath
     } elseif (Test-Path $exePath) {

--- a/azure-pipelines/Merge-CodeCoverage.ps1
+++ b/azure-pipelines/Merge-CodeCoverage.ps1
@@ -42,7 +42,7 @@ try {
             New-Item -Type Directory -Path (Split-Path $OutputFile) | Out-Null
         }
 
-        & dotnet tool run dotnet-coverage merge $Inputs -o $OutputFile -f cobertura
+        & dotnet dotnet-coverage merge $Inputs -o $OutputFile -f cobertura
     } else {
         Write-Error "No reports found to merge."
     }

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -8,10 +8,10 @@ parameters:
   default: true
 - name: EnableCompliance
   type: boolean
-  default: true
+  default: false
 - name: EnableAPIScan
   type: boolean
-  default: true
+  default: false
 
 jobs:
 - job: Windows

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -3,7 +3,7 @@ parameters:
 
 steps:
 
-- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
+- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) -warnaserror /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: 🛠 dotnet build
 
 - powershell: azure-pipelines/dotnet-test-cloud.ps1 -Configuration $(BuildConfiguration) -Agent $(Agent.JobName) -PublishResults

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -42,7 +42,6 @@ stages:
 
 - stage: Build
   variables:
-    MSBuildTreatWarningsAsErrors: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     BuildConfiguration: Release
     NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -4,13 +4,14 @@ parameters:
   default: true
 
 stages:
-- ${{ if parameters.ArchiveSymbols }}:
-  - stage: symbol_archive
-    displayName: Symbol archival
-    condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
-    jobs:
-    - job: archive
-      pool: VSEng-ReleasePool-1ES
+- stage: release
+  displayName: Publish
+  condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
+  jobs:
+  - ${{ if parameters.ArchiveSymbols }}:
+    - job: symbol_archive
+      displayName: Archive symbols
+      pool: VSEngSS-MicroBuild2022-1ES
       steps:
       - checkout: none
       - download: current
@@ -21,22 +22,20 @@ stages:
       - download: current
         artifact: symbols-legacy
         displayName: 🔻 Download symbols-legacy artifact
-      - task: MicroBuildArchiveSymbols@1
+      - task: MicroBuildArchiveSymbols@4
         displayName: 🔣 Archive symbols to Symweb
         inputs:
           SymbolsFeatureName: $(SymbolsFeatureName)
-          SymbolsSymwebProject: VS
-          SymbolsUncPath: \\cpvsbuild\drops\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildId)\Symbols.Archival
-          SymbolsEmailContacts: vsidemicrobuild
+          SymbolsProject: VS
           SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
+          azureSubscription: Symbols Upload (DevDiv)
       - task: MicroBuildCleanup@1
         displayName: ☎️ Send Telemetry
 
-- stage: azure_public_vssdk_feed
-  displayName: azure-public/vssdk feed
-  condition: and(succeeded(), eq(dependencies.Build.outputs['Windows.SetPipelineVariables.SignType'], 'Real'))
-  jobs:
   - job: push
+    displayName: azure-public/vssdk feed
+    ${{ if parameters.ArchiveSymbols }}:
+      dependsOn: symbol_archive
     pool:
       name: AzurePipelines-EO
       vmImage: AzurePipelinesUbuntu20.04compliant

--- a/azure-pipelines/secure-development-tools.yml
+++ b/azure-pipelines/secure-development-tools.yml
@@ -28,7 +28,6 @@ steps:
       !**/linux-*/**
       !**/osx*/**
     TargetFolder: $(Build.ArtifactStagingDirectory)/APIScanInputs
-  condition: and(succeeded(), ${{ parameters.EnableAPIScan }}, ne(variables.ApiScanClientId, ''))
 
 - task: BinSkim@4
   displayName: 🔍 Run BinSkim

--- a/azure-pipelines/variables/InsertVersionsValues.ps1
+++ b/azure-pipelines/variables/InsertVersionsValues.ps1
@@ -4,6 +4,8 @@
 # your libraries as defined in the src\ProductData\AssemblyVersions.tt file.
 return
 
+$MacroName = 'LibraryNoDotsVersion'
+$SampleProject = "$PSScriptRoot\..\..\src\LibraryName"
 [string]::join(',',(@{
-    ('LibraryNoDotsVersion') = & { (dotnet tool run nbgv get-version --project "$PSScriptRoot\..\..\src\LibraryName" --format json | ConvertFrom-Json).AssemblyVersion };
+    ($MacroName) = & { (dotnet nbgv get-version --project $SampleProject --format json | ConvertFrom-Json).AssemblyVersion };
 }.GetEnumerator() |% { "$($_.key)=$($_.value)" }))

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -17,8 +17,6 @@ stages:
   jobs:
   - template: build.yml
     parameters:
-      EnableCompliance: false
-      EnableAPIScan: false
       windowsPool: VSEngSS-MicroBuild2022-1ES
       includeMacOS: false
       RunTests: false

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.203",
+    "version": "7.0.302",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/init.ps1
+++ b/init.ps1
@@ -87,13 +87,13 @@ Push-Location $PSScriptRoot
 try {
     $HeaderColor = 'Green'
 
-    if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
-        $RestoreArguments = @()
-        if ($Interactive)
-        {
-            $RestoreArguments += '--interactive'
-        }
+    $RestoreArguments = @()
+    if ($Interactive)
+    {
+        $RestoreArguments += '--interactive'
+    }
 
+    if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
         dotnet restore @RestoreArguments
         if ($lastexitcode -ne 0) {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,12 @@
 <Project>
+  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <PropertyGroup>
+    <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Condition="Exists('README.md')" Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>


### PR DESCRIPTION
- Update Dockerfile
- Fix placement of $RestoreArguments construction
- Switch from `MSBuildTreatWarningsAsErrors` to `-warnaserror`
- Fix BinSkim when ApiScan won't run
- Bump .NET SDK to 7.0.302
- Parameterize and add diagnostics to InsertVersionsValues.ps1
- Fix schedule triggered source code archival
- Upgrade archive symbols task to v4
-  Consolidate two stages to just one
- Bump NB.GV to 3.6.132
- Bump CSharpIsNullAnalyzer from 0.1.329 to 0.1.495 (#204)
- Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 (#202)
- Bump dotnet-coverage from 17.7.0 to 17.7.1 (#205)
- (Hopefully) fix `nbgv` failures with `--` argument separator
- Fix indentation of commented section
- Bump Nerdbank.GitVersioning to 3.6.133
- Bump Microsoft.NET.Test.Sdk to 17.6.1
- Enable dependabot for Azure Repos
- Bump Microsoft.NET.Test.Sdk to 17.6.2
- Bump MicroBuild to 2.0.125
- Fix symbol file selection for R2R outputs
- Simplify `nbgv` invocation in ps1 scripts
- Skip compliance checks by default for build.yml
- Bump MicroBuild to 2.0.127
- Bump dotnet-coverage to 17.7.2
- Bump StyleCop.Analyzers.Unstable from 1.2.0.435 to 1.2.0.507 (#207)
- Bump dotnet-coverage from 17.7.2 to 17.7.3 (#208)
- Bump MicroBuildVersion to 2.0.130
- Bump Microsoft.NET.Test.Sdk to 17.6.3
- Bump powershell to 7.3.5
- Automatically include a README.md from the project directory
