### PR TITLE
Bump version and fix local packing

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes.csproj
@@ -34,7 +34,7 @@
   <Target Name="PackBuildOutputs" BeforeTargets="_GetPackageFiles" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">
     <ItemGroup>
       <Content Include="$(TargetDir)Microsoft.VisualStudio.SDK.Analyzers.dll" Pack="true" PackagePath="analyzers\cs\" />
-      <Content Include="$(TargetDir)Microsoft.VisualStudio.SDK.Analyzers.pdb" Pack="true" PackagePath="analyzers\cs\" />
+      <Content Include="$(TargetDir)Microsoft.VisualStudio.SDK.Analyzers.pdb" Pack="true" PackagePath="analyzers\cs\" Condition="'$(IncludeSymbols)'=='true'" />
       <Content Include="$(TargetPath)" Pack="true" PackagePath="analyzers\cs\" />
       <Content Include="@(DebugSymbolsProjectOutputGroupOutput)" Pack="true" PackagePath="analyzers\cs\" />
       <Content Include="@(SatelliteDllsProjectOutputGroupOutput)" Pack="true" PackagePath="analyzers\cs\%(SatelliteDllsProjectOutputGroupOutput.Culture)\" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "16.10",
+  "version": "17.7",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
- Bump version to 17.7
- Fix the pack target when run locally (where no pdb files are created).