### PR TITLE
Switch VSSDK006 to an operation-based analyzer

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Utils.cs
@@ -43,6 +43,26 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         /// </summary>
         /// <param name="handler">The handler to wrap.</param>
         /// <returns>The debug-ready handler.</returns>
+        internal static Action<OperationAnalysisContext> DebuggableWrapper(Action<OperationAnalysisContext> handler)
+        {
+            return ctxt =>
+            {
+                try
+                {
+                    handler(ctxt);
+                }
+                catch (Exception ex) when (LaunchDebuggerExceptionFilter())
+                {
+                    throw new Exception($"Analyzer failure while processing symbol {ctxt.Operation} at {ctxt.Operation.Syntax.GetLocation().SourceTree?.FilePath}({ctxt.Operation.Syntax.GetLocation().GetLineSpan().StartLinePosition.Line},{ctxt.Operation.Syntax.GetLocation().GetLineSpan().StartLinePosition.Character}): {ex.GetType()} {ex.Message}", ex);
+                }
+            };
+        }
+
+        /// <summary>
+        /// Wraps an analyzer processor with a Debugger.Launch call in an exception filter for debug builds.
+        /// </summary>
+        /// <param name="handler">The handler to wrap.</param>
+        /// <returns>The debug-ready handler.</returns>
         internal static Action<SymbolAnalysisContext> DebuggableWrapper(Action<SymbolAnalysisContext> handler)
         {
             return ctxt =>


### PR DESCRIPTION
This substantially fixes the VSSDK006 perf hit during compilation.

The crux of the perf issue was our calling `GetSymbolInfo` and `GetSemanticModel` from syntax-based analyzers. That is painfully slow. While these calls remain after this fix, switching from a syntax-based to an IOperation based analyzer causes the analyzer to run when the compiler has already built up the semantic models and symbol info, making accessing this same data very cheap.

Fixes #241