### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,13 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.7",
+      "version": "7.4.1",
       "commands": [
         "pwsh"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "dotnet-coverage": {
-      "version": "17.8.6",
+      "version": "17.10.1",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -40,6 +40,7 @@ indent_size = 4
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
 dotnet_style_qualification_for_field = true:warning
 dotnet_style_qualification_for_property = true:warning
 dotnet_style_qualification_for_method = true:warning

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  ignore:
-  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-  - dependency-name: dotnet-format
-    versions: ["6.x", "7.x", "8.x"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,12 @@
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
+  "azure-pipelines.1ESPipelineTemplatesSchemaFile": true,
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
-  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true
+  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+  "editor.formatOnSave": true,
+  "[xml]": {
+    "editor.wordWrap": "off"
+  }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -5,7 +6,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
@@ -8,4 +9,6 @@
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />
   </ItemGroup>
+
+  <Import Project="azure-pipelines\NuGetSbom.targets" Condition="'$(IsPackable)'!='false'" />
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- https://learn.microsoft.com/nuget/consume-packages/central-package-management -->
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
-    <MicroBuildVersion>2.0.146</MicroBuildVersion>
+    <MicroBuildVersion>2.0.147</MicroBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.4.0" />
@@ -12,7 +13,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces" Version="17.8.36938" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.4.33011.337" />
@@ -23,8 +24,8 @@
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit.runner.console" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
@@ -32,10 +33,9 @@
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
   <ItemGroup>
-    <!-- <GlobalPackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.1.1" /> -->
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Install-NuGetPackage.ps1
+++ b/azure-pipelines/Install-NuGetPackage.ps1
@@ -45,7 +45,7 @@ try {
 
     if ($PSCmdlet.ShouldProcess($PackageId, 'nuget install')) {
         $p = Start-Process $nugetPath $nugetArgs -NoNewWindow -Wait -PassThru
-        if ($p.ExitCode -ne 0) { throw }
+        if ($null -ne $p.ExitCode -and $p.ExitCode -ne 0) { throw }
     }
 
     # Provide the path to the installed package directory to our caller.

--- a/azure-pipelines/NuGetSbom.targets
+++ b/azure-pipelines/NuGetSbom.targets
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <GenerateSBOMThisProject>true</GenerateSBOMThisProject>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeSbomInNupkg</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="IncludeSbomInNupkg">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(SbomOutput)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/azure-pipelines/archive-sourcecode.yml
+++ b/azure-pipelines/archive-sourcecode.yml
@@ -11,6 +11,13 @@ schedules:
     include:
     - main
 
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
 parameters:
 - name: notes
   displayName: Notes to include in the SCA request
@@ -24,35 +31,47 @@ parameters:
 variables:
 - group: VS Core team # Expected to provide ManagerAlias, SourceCodeArchivalUri
 
-pool:
-  name: AzurePipelines-EO
-  vmImage: AzurePipelinesUbuntu20.04compliant
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
 
-steps:
-- checkout: self
-  clean: true
-  fetchDepth: 0
-- powershell: tools/Install-DotNetSdk.ps1
-  displayName: ⚙ Install .NET SDK
-- task: NuGetAuthenticate@1
-  displayName: 🔏 Authenticate NuGet feeds
-  inputs:
-    forceReinstallCredentialProvider: true
-- script: dotnet tool restore
-  displayName: ⚙️ Restore CLI tools
-- powershell: azure-pipelines/variables/_pipelines.ps1
-  failOnStderr: true
-  displayName: ⚙ Set pipeline variables based on source
-- powershell: >
-    $TeamAlias = '$(TeamEmail)'.Substring(0, '$(TeamEmail)'.IndexOf('@'))
+    stages:
+    - stage: archive
+      jobs:
+      - job: archive
+        pool:
+          name: AzurePipelines-EO
+          demands:
+          - ImageOverride -equals AzurePipelinesUbuntu20.04compliantGPT
+          os: Linux
 
-    azure-pipelines/Archive-SourceCode.ps1
-    -ManagerAlias '$(ManagerAlias)'
-    -TeamAlias $TeamAlias
-    -BusinessGroupName '$(BusinessGroupName)'
-    -ProductName '$(SymbolsFeatureName)'
-    -ProductLanguage English
-    -Notes '${{ parameters.notes }}'
-    -Verbose
-    -WhatIf:$${{ parameters.whatif }}
-  displayName: 🗃️ Submit archival request
+        steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 0
+        - powershell: tools/Install-DotNetSdk.ps1
+          displayName: ⚙ Install .NET SDK
+        - task: NuGetAuthenticate@1
+          displayName: 🔏 Authenticate NuGet feeds
+          inputs:
+            forceReinstallCredentialProvider: true
+        - script: dotnet tool restore
+          displayName: ⚙️ Restore CLI tools
+        - powershell: azure-pipelines/variables/_pipelines.ps1
+          failOnStderr: true
+          displayName: ⚙ Set pipeline variables based on source
+        - powershell: >
+            $TeamAlias = '$(TeamEmail)'.Substring(0, '$(TeamEmail)'.IndexOf('@'))
+
+            azure-pipelines/Archive-SourceCode.ps1
+            -ManagerAlias '$(ManagerAlias)'
+            -TeamAlias $TeamAlias
+            -BusinessGroupName '$(BusinessGroupName)'
+            -ProductName '$(SymbolsFeatureName)'
+            -ProductLanguage English
+            -Notes '${{ parameters.notes }}'
+            -Verbose
+            -WhatIf:$${{ parameters.whatif }}
+          displayName: 🗃️ Submit archival request

--- a/azure-pipelines/artifacts/_pipelines.ps1
+++ b/azure-pipelines/artifacts/_pipelines.ps1
@@ -7,7 +7,8 @@
 [CmdletBinding()]
 param (
     [string]$ArtifactNameSuffix,
-    [switch]$StageOnly
+    [switch]$StageOnly,
+    [switch]$AvoidSymbolicLinks
 )
 
 Function Set-PipelineVariable($name, $value) {
@@ -24,7 +25,7 @@ Function Test-ArtifactUploaded($artifactName) {
     Test-Path "env:$varName"
 }
 
-& "$PSScriptRoot/_stage_all.ps1" -ArtifactNameSuffix $ArtifactNameSuffix |% {
+& "$PSScriptRoot/_stage_all.ps1" -ArtifactNameSuffix $ArtifactNameSuffix -AvoidSymbolicLinks:$AvoidSymbolicLinks |% {
     # Set a variable which will out-live this script so that a subsequent attempt to collect and upload artifacts
     # will skip this one from a check in the _all.ps1 script.
     Set-PipelineVariable "ARTIFACTSTAGED_$($_.Name.ToUpper())" 'true'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -12,6 +12,17 @@ parameters:
 - name: EnableAPIScan
   type: boolean
   default: false
+- name: artifact_names
+  type: object
+  default:
+  - build_logs
+  - coverageResults
+  - deployables
+  - projectAssetsJson
+  - symbols
+  - testResults
+  - test_symbols
+  - Variables
 
 jobs:
 - job: Windows
@@ -21,6 +32,25 @@ jobs:
   - ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
     # https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline
     - group: VSCloudServices-APIScan # Expected to provide ApiScanClientId, ApiScanSecret, ApiScanTenant
+  ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
+    templateContext:
+      outputParentDirectory: $(Build.ArtifactStagingDirectory)
+      outputs:
+      - ${{ each artifact_name in parameters.artifact_names }}:
+        - output: pipelineArtifact
+          displayName: 📢 Publish ${{ artifact_name }}-Windows
+          targetPath: $(Build.ArtifactStagingDirectory)/${{ artifact_name }}-Windows
+          artifactName: ${{ artifact_name }}-Windows
+      - output: pipelineArtifact
+        displayName: 📢 Publish VSInsertion-Windows
+        targetPath: $(Build.ArtifactStagingDirectory)/VSInsertion-Windows
+        artifactName: VSInsertion-Windows
+      # This is useful when false positives appear so we can copy some of the output into the suppressions file.
+      - output: pipelineArtifact
+        displayName: 📢 Publish Guardian failures
+        targetPath: $(Build.ArtifactStagingDirectory)/guardian_failures_as_suppressions
+        artifactName: guardian_failures_as_suppressions
+        condition: failed()
   steps:
   - checkout: self
     fetchDepth: 0 # avoid shallow clone so nbgv can do its work.

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -15,10 +15,17 @@ steps:
   displayName: ⚙ Update pipeline variables based on build outputs
   condition: succeededOrFailed()
 
-- powershell: azure-pipelines/artifacts/_pipelines.ps1 -ArtifactNameSuffix "-$(Agent.JobName)" -Verbose
-  failOnStderr: true
-  displayName: 📢 Publish artifacts
-  condition: succeededOrFailed()
+- ${{ if eq(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
+  - powershell: azure-pipelines/artifacts/_pipelines.ps1 -StageOnly -AvoidSymbolicLinks -ArtifactNameSuffix "-$(Agent.JobName)" -Verbose
+    failOnStderr: true
+    displayName: 📢 Publish artifacts
+    condition: succeededOrFailed()
+
+- ${{ if ne(variables['system.collectionId'], '011b8bdf-6d56-4f87-be0d-0092136884d9') }}:
+  - powershell: azure-pipelines/artifacts/_pipelines.ps1 -ArtifactNameSuffix "-$(Agent.JobName)" -Verbose
+    failOnStderr: true
+    displayName: 📢 Publish artifacts
+    condition: succeededOrFailed()
 
 - ${{ if and(ne(variables['codecov_token'], ''), parameters.RunTests) }}:
   - powershell: |

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -10,10 +10,6 @@ steps:
       $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)/NuGet
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- task: MicroBuildCleanup@1
-  condition: succeededOrFailed()
-  displayName: ⚙️ MicroBuild Cleanup
-
 - task: Ref12Analyze@0
   displayName: 📑 Ref12 (Codex) Analyze
   inputs:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -38,23 +38,55 @@ parameters:
   type: boolean
   default: true
 
-stages:
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-- stage: Build
-  variables:
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    BuildConfiguration: Release
-    NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
-    SignTypeSelection: ${{ parameters.SignTypeSelection }}
-    Packaging.EnableSBOMSigning: false
-    Codeql.Enabled: true
-
-  jobs:
-  - template: build.yml
+extends:
+  ${{ if parameters.EnableCompliance }}:
+    template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
     parameters:
-      EnableCompliance: ${{ parameters.EnableCompliance }}
-      EnableAPIScan: ${{ parameters.EnableAPIScan }}
-      windowsPool: VSEngSS-MicroBuild2022-1ES
-      RunTests: ${{ parameters.RunTests }}
-
-- template: prepare-insertion-stages.yml
+      sdl:
+        sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      stages:
+      - stage: Build
+        variables:
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+          BuildConfiguration: Release
+          NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
+          SignTypeSelection: ${{ parameters.SignTypeSelection }}
+          Packaging.EnableSBOMSigning: false
+          Codeql.Enabled: true
+        jobs:
+        - template: /azure-pipelines/build.yml@self
+          parameters:
+            EnableCompliance: ${{ parameters.EnableCompliance }}
+            EnableAPIScan: ${{ parameters.EnableAPIScan }}
+            windowsPool: VSEngSS-MicroBuild2022-1ES
+            RunTests: ${{ parameters.RunTests }}
+      - template: /azure-pipelines/prepare-insertion-stages.yml@self
+  ${{ else }}:
+    template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
+    parameters:
+      sdl:
+        sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      stages:
+      - stage: Build
+        variables:
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+          BuildConfiguration: Release
+          NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
+          SignTypeSelection: ${{ parameters.SignTypeSelection }}
+          Packaging.EnableSBOMSigning: false
+          Codeql.Enabled: true
+        jobs:
+        - template: /azure-pipelines/build.yml@self
+          parameters:
+            EnableCompliance: ${{ parameters.EnableCompliance }}
+            EnableAPIScan: ${{ parameters.EnableAPIScan }}
+            windowsPool: VSEngSS-MicroBuild2022-1ES
+            RunTests: ${{ parameters.RunTests }}
+      - template: /azure-pipelines/prepare-insertion-stages.yml@self

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -29,8 +29,6 @@ stages:
           SymbolsProject: VS
           SymbolsAgentPath: $(Pipeline.Workspace)/symbols-legacy
           azureSubscription: Symbols Upload (DevDiv)
-      - task: MicroBuildCleanup@1
-        displayName: ☎️ Send Telemetry
 
   - job: push
     displayName: azure-public/vssdk feed
@@ -38,7 +36,9 @@ stages:
       dependsOn: symbol_archive
     pool:
       name: AzurePipelines-EO
-      vmImage: AzurePipelinesUbuntu20.04compliant
+      demands:
+      - ImageOverride -equals AzurePipelinesUbuntu20.04compliantGPT
+      os: Linux
     steps:
     - checkout: none
     - download: current

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -2,6 +2,11 @@ trigger: none # We only want to trigger manually or based on resources
 pr: none
 
 resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
   pipelines:
   - pipeline: CI
     source: VSSDK-Analyzers
@@ -12,50 +17,60 @@ resources:
 variables:
 - group: VS SDK feeds # Expected to provide NuGetOrgApiKey
 
-jobs:
-- job: release
-  pool:
-    name: AzurePipelines-EO
-    vmImage: AzurePipelinesUbuntu20.04compliant
-  steps:
-  - checkout: none
-  - powershell: |
-      Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-      if ('$(resources.pipeline.CI.runName)'.Contains('-')) {
-        Write-Host "##vso[task.setvariable variable=IsPrerelease]true"
-      } else {
-        Write-Host "##vso[task.setvariable variable=IsPrerelease]false"
-      }
-    displayName: ⚙ Set up pipeline
-  - task: UseDotNet@2
-    displayName: ⚙ Install .NET SDK
-    inputs:
-      packageType: sdk
-      version: 6.x
-  - download: CI
-    artifact: deployables-Windows
-    displayName: 🔻 Download deployables-Windows artifact
-    patterns: 'deployables-Windows/NuGet/*'
-  - task: GitHubRelease@1
-    displayName: 📢 GitHub release (create)
-    inputs:
-      gitHubConnection: AArnott
-      repositoryName: $(Build.Repository.Name)
-      target: $(resources.pipeline.CI.sourceCommit)
-      tagSource: userSpecifiedTag
-      tag: v$(resources.pipeline.CI.runName)
-      title: v$(resources.pipeline.CI.runName)
-      isDraft: true # After running this step, visit the new draft release, edit, and publish.
-      isPreRelease: $(IsPrerelease)
-      assets: $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg
-      changeLogCompareToRelease: lastNonDraftRelease
-      changeLogType: issueBased
-      changeLogLabels: |
-        [
-          { "label" : "breaking change", "displayName" : "Breaking changes", "state" : "closed" },
-          { "label" : "bug", "displayName" : "Fixes", "state" : "closed" },
-          { "label" : "enhancement", "displayName": "Enhancements", "state" : "closed" }
-        ]
-  - script: dotnet nuget push $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg -s https://api.nuget.org/v3/index.json --api-key $(NuGetOrgApiKey) --skip-duplicate
-    displayName: 📦 Push packages to nuget.org
-    condition: and(succeeded(), ne(variables['NuGetOrgApiKey'], ''))
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+
+    stages:
+    - stage: release
+      jobs:
+      - job: release
+        pool:
+          name: AzurePipelines-EO
+          demands:
+          - ImageOverride -equals AzurePipelinesUbuntu20.04compliantGPT
+          os: Linux
+        steps:
+        - checkout: none
+        - powershell: |
+            Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
+            if ('$(resources.pipeline.CI.runName)'.Contains('-')) {
+              Write-Host "##vso[task.setvariable variable=IsPrerelease]true"
+            } else {
+              Write-Host "##vso[task.setvariable variable=IsPrerelease]false"
+            }
+          displayName: ⚙ Set up pipeline
+        - task: UseDotNet@2
+          displayName: ⚙ Install .NET SDK
+          inputs:
+            packageType: sdk
+            version: 6.x
+        - download: CI
+          artifact: deployables-Windows
+          displayName: 🔻 Download deployables-Windows artifact
+          patterns: 'deployables-Windows/NuGet/*'
+        - task: GitHubRelease@1
+          displayName: 📢 GitHub release (create)
+          inputs:
+            gitHubConnection: AArnott
+            repositoryName: $(Build.Repository.Name)
+            target: $(resources.pipeline.CI.sourceCommit)
+            tagSource: userSpecifiedTag
+            tag: v$(resources.pipeline.CI.runName)
+            title: v$(resources.pipeline.CI.runName)
+            isDraft: true # After running this step, visit the new draft release, edit, and publish.
+            isPreRelease: $(IsPrerelease)
+            assets: $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg
+            changeLogCompareToRelease: lastNonDraftRelease
+            changeLogType: issueBased
+            changeLogLabels: |
+              [
+                { "label" : "breaking change", "displayName" : "Breaking changes", "state" : "closed" },
+                { "label" : "bug", "displayName" : "Fixes", "state" : "closed" },
+                { "label" : "enhancement", "displayName": "Enhancements", "state" : "closed" }
+              ]
+        - script: dotnet nuget push $(Pipeline.Workspace)/CI/deployables-Windows/NuGet/*.nupkg -s https://api.nuget.org/v3/index.json --api-key $(NuGetOrgApiKey) --skip-duplicate
+          displayName: 📦 Push packages to nuget.org
+          condition: and(succeeded(), ne(variables['NuGetOrgApiKey'], ''))

--- a/azure-pipelines/secure-development-tools.yml
+++ b/azure-pipelines/secure-development-tools.yml
@@ -6,18 +6,8 @@ steps:
 - powershell: echo "##vso[build.addbuildtag]compliance"
   displayName: 🏷️ Tag run with 'compliance'
 
-- task: CredScan@3
-  displayName: 🔍 Run CredScan
-
-- task: PoliCheck@2
-  displayName: 🔍 Run PoliCheck
-  inputs:
-    targetType: F
-    targetArgument: $(System.DefaultWorkingDirectory)
-    optionsUEPATH: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml
-
 - task: CopyFiles@2
-  displayName: 📂 Collect APIScan/BinSkim inputs
+  displayName: 📂 Collect APIScan inputs
   inputs:
     SourceFolder: $(Build.ArtifactStagingDirectory)/Symbols-$(Agent.JobName)
     # Exclude any patterns from the Contents (e.g. `!**/git2*`) that we have symbols for but do not need to run APIScan on.
@@ -28,14 +18,6 @@ steps:
       !**/linux-*/**
       !**/osx*/**
     TargetFolder: $(Build.ArtifactStagingDirectory)/APIScanInputs
-
-- task: BinSkim@4
-  displayName: 🔍 Run BinSkim
-  inputs:
-    InputType: Basic
-    Function: analyze
-    TargetPattern: guardianGlob
-    AnalyzeTargetGlob: $(Build.ArtifactStagingDirectory)/APIScanInputs/**/*.dll;$(Build.ArtifactStagingDirectory)/APIScanInputs/**/*.exe
 
 - task: APIScan@2
   displayName: 🔍 Run APIScan
@@ -72,9 +54,3 @@ steps:
     GdnBreakSuppressionSets: falsepositives
     GdnBreakOutputSuppressionFile: $(Build.ArtifactStagingDirectory)/guardian_failures_as_suppressions/
     GdnBreakOutputSuppressionSet: falsepositives
-
-# This is useful when false positives appear so we can copy some of the output into the suppressions file.
-- publish: $(Build.ArtifactStagingDirectory)/guardian_failures_as_suppressions
-  artifact: guardian_failures_as_suppressions
-  displayName: 🔍 Publish Guardian failures
-  condition: failed()

--- a/azure-pipelines/variables/TeamName.ps1
+++ b/azure-pipelines/variables/TeamName.ps1
@@ -1,2 +1,2 @@
-# This value is used to craft a \\cpvsbuild\drops path for symbol archival.
+# This value is used as an input to the MicroBuild Insert VS task.
 'VS IDE'

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -2,6 +2,11 @@ trigger: none # We only want to trigger manually or based on resources
 pr: none
 
 resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
   pipelines:
   - pipeline: CI
     source: VSSDK-Analyzers
@@ -12,46 +17,52 @@ resources:
       - Real signed
       - auto-insertion
 
-jobs:
-- job: insertion
-  displayName: VS insertion
-  pool: VSEngSS-MicroBuild2022-1ES
-  steps:
-  - checkout: none
-  - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-    displayName: ⚙️ Set pipeline name
-  - task: UseDotNet@2
-    displayName: ⚙️ Install .NET SDK
-    inputs:
-      packageType: sdk
-      version: 6.x
-  - task: NuGetAuthenticate@1
-    displayName: 🔏 Authenticate NuGet feeds
-    inputs:
-      forceReinstallCredentialProvider: true
-  - template: release-deployment-prep.yml
-  - download: CI
-    artifact: VSInsertion-Windows
-    displayName: 🔻 Download VSInsertion-Windows artifact
-  - script: dotnet nuget push $(Pipeline.Workspace)\CI\VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
-    displayName: 📦 Push CoreXT packages to VS feed
-  - task: MicroBuildInsertVsPayload@4
-    displayName: 🏭 Insert VS Payload
-    inputs:
-      TeamName: $(TeamName)
-      TeamEmail: $(TeamEmail)
-      InsertionPayloadName: $(Build.Repository.Name) $(Build.BuildNumber)
-      InsertionBuildPolicy: Request Perf DDRITs
-      AutoCompletePR: true
-      AutoCompleteMergeStrategy: Squash
-  - task: MicroBuildCleanup@1
-    displayName: ☎️ Send Telemetry
-  - powershell: |
-      $contentType = 'application/json';
-      $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
-      $rawRequest = @{ daysValid = 365 * 2; definitionId = $(resources.pipeline.CI.pipelineID); ownerId = 'User:$(Build.RequestedForId)'; protectPipeline = $false; runId = $(resources.pipeline.CI.runId) };
-      $request = ConvertTo-Json @($rawRequest);
-      Write-Host $request
-      $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.1";
-      Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;
-    displayName: 🗻 Retain inserted builds
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+
+    stages:
+    - stage: insertion
+      jobs:
+      - job: insertion
+        displayName: VS insertion
+        pool: VSEngSS-MicroBuild2022-1ES
+        steps:
+        - checkout: none
+        - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
+          displayName: ⚙️ Set pipeline name
+        - task: UseDotNet@2
+          displayName: ⚙️ Install .NET SDK
+          inputs:
+            packageType: sdk
+            version: 6.x
+        - task: NuGetAuthenticate@1
+          displayName: 🔏 Authenticate NuGet feeds
+          inputs:
+            forceReinstallCredentialProvider: true
+        - template: azure-pipelines/release-deployment-prep.yml@self
+        - download: CI
+          artifact: VSInsertion-Windows
+          displayName: 🔻 Download VSInsertion-Windows artifact
+        - script: dotnet nuget push $(Pipeline.Workspace)\CI\VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
+          displayName: 📦 Push CoreXT packages to VS feed
+        - task: MicroBuildInsertVsPayload@4
+          displayName: 🏭 Insert VS Payload
+          inputs:
+            TeamName: $(TeamName)
+            TeamEmail: $(TeamEmail)
+            InsertionPayloadName: $(Build.Repository.Name) $(Build.BuildNumber)
+            InsertionBuildPolicy: Request Perf DDRITs
+            AutoCompletePR: true
+            AutoCompleteMergeStrategy: Squash
+        - powershell: |
+            $contentType = 'application/json';
+            $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
+            $rawRequest = @{ daysValid = 365 * 2; definitionId = $(resources.pipeline.CI.pipelineID); ownerId = 'User:$(Build.RequestedForId)'; protectPipeline = $false; runId = $(resources.pipeline.CI.runId) };
+            $request = ConvertTo-Json @($rawRequest);
+            Write-Host $request
+            $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.1";
+            Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;
+          displayName: 🗻 Retain inserted builds

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -5,77 +5,88 @@
 trigger: none # We only want to trigger manually or based on resources
 pr: none
 
-stages:
-- stage: Build
-  variables:
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-    NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
-    SignTypeSelection: Real
-    BuildConfiguration: Release
-    ValidationBuild: true
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-  jobs:
-  - template: build.yml
-    parameters:
-      windowsPool: VSEngSS-MicroBuild2022-1ES
-      includeMacOS: false
-      RunTests: false
-
-- template: prepare-insertion-stages.yml
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
-    ArchiveSymbols: false
+    sdl:
+      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
 
-- stage: insertion
-  displayName: VS insertion
-  jobs:
-  - job: insertion
-    displayName: VS insertion
-    pool: VSEngSS-MicroBuild2022-1ES
-    steps:
-    - checkout: self
-      clean: true
-      fetchDepth: 1
-    - task: UseDotNet@2
-      displayName: ⚙️ Install .NET SDK
-      inputs:
-        packageType: sdk
-        version: 6.x
-    - task: NuGetAuthenticate@1
-      displayName: 🔏 Authenticate NuGet feeds
-      inputs:
-        forceReinstallCredentialProvider: true
-    - download: current
-      artifact: Variables-Windows
-      displayName: 🔻 Download Variables-Windows artifact
-    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
-      displayName: ⚙️ Set pipeline variables based on artifacts
-    - download: current
-      artifact: VSInsertion-Windows
-      displayName: 🔻 Download VSInsertion-Windows artifact
-    - script: dotnet nuget push VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
-      displayName: 📦 Push CoreXT packages to VS feed
-      workingDirectory: $(Pipeline.Workspace)
-    - task: MicroBuildInsertVsPayload@4
-      displayName: 🏭 Insert VS Payload
-      inputs:
-        TeamName: $(TeamName)
-        TeamEmail: $(TeamEmail)
-        InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck]
-        InsertionDescription: |
-          This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.
-        CustomScriptExecutionCommand: src/VSSDK/NuGet/AllowUnstablePackages.ps1
-        InsertionBuildPolicy: Request Perf DDRITs
-        InsertionReviewers: $(Build.RequestedForEmail)
-        AutoCompletePR: false
-    - powershell: |
-        $insertionPRId = azure-pipelines/Get-InsertionPRId.ps1
-        $Markdown = @"
-        Validation insertion pull request created: !$insertionPRId
-        Please check status there before proceeding to merge this PR.
-        Remember to Abandon and (if allowed) to Delete Source Branch on that insertion PR when validation is complete.
-        "@
-        azure-pipelines/PostPRMessage.ps1 -AccessToken '$(System.AccessToken)' -Markdown $Markdown -Verbose
-      displayName: ✏️ Comment on pull request
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-    - task: MicroBuildCleanup@1
-      displayName: ☎️ Send Telemetry
+    stages:
+    - stage: Build
+      variables:
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
+        SignTypeSelection: Real
+        BuildConfiguration: Release
+        ValidationBuild: true
+
+      jobs:
+      - template: /azure-pipelines/build.yml@self
+        parameters:
+          windowsPool: VSEngSS-MicroBuild2022-1ES
+          includeMacOS: false
+          RunTests: false
+
+    - template: /azure-pipelines/prepare-insertion-stages.yml@self
+      parameters:
+        ArchiveSymbols: false
+
+    - stage: insertion
+      displayName: VS insertion
+      jobs:
+      - job: insertion
+        displayName: VS insertion
+        pool: VSEngSS-MicroBuild2022-1ES
+        steps:
+        - checkout: self
+          clean: true
+          fetchDepth: 1
+        - task: UseDotNet@2
+          displayName: ⚙️ Install .NET SDK
+          inputs:
+            packageType: sdk
+            version: 6.x
+        - task: NuGetAuthenticate@1
+          displayName: 🔏 Authenticate NuGet feeds
+          inputs:
+            forceReinstallCredentialProvider: true
+        - download: current
+          artifact: Variables-Windows
+          displayName: 🔻 Download Variables-Windows artifact
+        - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+          displayName: ⚙️ Set pipeline variables based on artifacts
+        - download: current
+          artifact: VSInsertion-Windows
+          displayName: 🔻 Download VSInsertion-Windows artifact
+        - script: dotnet nuget push VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
+          displayName: 📦 Push CoreXT packages to VS feed
+          workingDirectory: $(Pipeline.Workspace)
+        - task: MicroBuildInsertVsPayload@4
+          displayName: 🏭 Insert VS Payload
+          inputs:
+            TeamName: $(TeamName)
+            TeamEmail: $(TeamEmail)
+            InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck]
+            InsertionDescription: |
+              This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.
+            CustomScriptExecutionCommand: src/VSSDK/NuGet/AllowUnstablePackages.ps1
+            InsertionBuildPolicy: Request Perf DDRITs
+            InsertionReviewers: $(Build.RequestedForEmail)
+            AutoCompletePR: false
+        - powershell: |
+            $insertionPRId = azure-pipelines/Get-InsertionPRId.ps1
+            $Markdown = @"
+            Validation insertion pull request created: !$insertionPRId
+            Please check status there before proceeding to merge this PR.
+            Remember to Abandon and (if allowed) to Delete Source Branch on that insertion PR when validation is complete.
+            "@
+            azure-pipelines/PostPRMessage.ps1 -AccessToken '$(System.AccessToken)' -Markdown $Markdown -Verbose
+          displayName: ✏️ Comment on pull request
+          condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "8.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/init.ps1
+++ b/init.ps1
@@ -88,8 +88,7 @@ try {
     $HeaderColor = 'Green'
 
     $RestoreArguments = @()
-    if ($Interactive)
-    {
+    if ($Interactive) {
         $RestoreArguments += '--interactive'
     }
 
@@ -102,10 +101,10 @@ try {
     }
 
     if (!$NoToolRestore -and $PSCmdlet.ShouldProcess("dotnet tool", "restore")) {
-      dotnet tool restore @RestoreArguments
-      if ($lastexitcode -ne 0) {
-          throw "Failure while restoring dotnet CLI tools."
-      }
+        dotnet tool restore @RestoreArguments
+        if ($lastexitcode -ne 0) {
+            throw "Failure while restoring dotnet CLI tools."
+        }
     }
 
     $InstallNuGetPkgScriptPath = "$PSScriptRoot\azure-pipelines\Install-NuGetPackage.ps1"

--- a/settings.VisualStudio.json
+++ b/settings.VisualStudio.json
@@ -1,0 +1,3 @@
+{
+  "textEditor.codeCleanup.profile": "profile1"
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 </Project>


### PR DESCRIPTION
- Bump dotnet-coverage to 17.8.7
- Revert "Bump dotnet-coverage to 17.8.7"
- Bump .NET SDK to 7.0.401
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
- Bump xunit from 2.5.2 to 2.5.3 (#226)
- Bump dotnet-coverage from 17.9.1 to 17.9.3 (#225)
- Bump powershell from 7.3.8 to 7.3.9 (#227)
- Bump xunit from 2.5.3 to 2.6.1 (#228)
- Ignore `dotnet-format` v9 versions
- Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 (#229)
- Apply Directory.Packages.props in Apply-Template.ps1
- Bump to the .NET 8.0.100 SDK
- Bump xunit from 2.6.1 to 2.6.2 (#234)
- Bump Microsoft.SourceLink.GitHub from 1.1.1 to 8.0.0 (#232)
- Bump powershell from 7.3.9 to 7.4.0 (#231)
- Bump xunit.runner.visualstudio from 2.5.3 to 2.5.4 (#233)
- Validate formatted code in builds
- Enable auto-format on save in VS and VS Code
- Remove `dotnet-format` as a tool
- Make symbolic link failures more detectable
- Update TeamName comment
- Add xml header to msbuild files
- Update Microsoft.SourceLink.AzureRepos.Git to 8.0.0
- Stop VS Code from wrapping xml files
- Add dotnet_separate_import_directive_groups to .editorconfig
- Bump xunit from 2.6.2 to 2.6.3 (#239)
- Bump dotnet-coverage from 17.9.3 to 17.9.5 (#238)
- Bump xunit.runner.visualstudio from 2.5.4 to 2.5.5 (#237)
- Include SBOM in nuget packages
- Fix `Install-NuGetPackage` exit code check
- Bump dotnet-coverage from 17.9.5 to 17.9.6 (#240)
- Bump xunit.runner.visualstudio from 2.5.5 to 2.5.6 (#243)
- Bump xunit from 2.6.3 to 2.6.4 (#242)
- Bump StyleCop.Analyzers.Unstable from 1.2.0.507 to 1.2.0.556 (#241)
- Bump MicroBuild to 2.0.147
- Bump powershell from 7.4.0 to 7.4.1 (#245)
- Bump xunit from 2.6.4 to 2.6.6
- Add switch to avoid creating symbolic links
- Clarify parameter type in AzP template
- MicroBuild to 1ES PT template transition (#246)
- Update the other 4 entrypoints for 1ES PT
- Switch vs-validation pipeline to Unofficial template
- Bump dotnet-coverage from 17.9.6 to 17.10.1Bumps [dotnet-coverage](https://github.com/microsoft/codecoverage) from 17.9.6 to 17.10.1.- [Commits](https://github.com/microsoft/codecoverage/commits)---updated-dependencies:- dependency-name: dotnet-coverage  dependency-type: direct:production  update-type: version-update:semver-minor...Signed-off-by: dependabot[bot] <support@github.com>
- Format init.ps1
- Fix NUGET_PACKAGES path in pipelines
- Fix the pool for pushing real-signed packages to be 1ES PT compliant
