### PR TITLE
Add file change services

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
@@ -103,6 +103,8 @@
 ![Microsoft.VisualStudio.Shell.Interop.SVsAppContainerProjectDeploy]
 ![Microsoft.VisualStudio.Shell.Interop.IVsExecutionContextTracker]
 ![Microsoft.VisualStudio.Shell.Interop.SVsExecutionContextTracker]
+![Microsoft.VisualStudio.Shell.Interop.IVsFileChangeEx3]
+![Microsoft.VisualStudio.Shell.Interop.SVsFileChangeEx]
 ![Microsoft.VisualStudio.Shell.Interop.IVsInvalidateCachedCommandState]
 ![Microsoft.VisualStudio.Shell.Interop.SVsInvalidateCachedCommandState]
 ![Microsoft.VisualStudio.Shell.Interop.IVsPackageInfo]


### PR DESCRIPTION
Most of the COM interfaces of the file change service JTF.Run from a background thread and hence are not safe to use. The IVsAsyncFileChangeEx and IVsAsyncFileChangeEx2 are safe to use but they live in a namespace that is currently covered by this file and hence don't need to be opt'd out.