### PR TITLE
Change ServiceProvider ban to just CreateFromSetSite

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
@@ -1,9 +1,12 @@
+# NOTE: While there no examples below, members *must* be listed before their declaring type, otherwise
+# their given designation will be ignored. Namespaces and types can be listed in any order.
+
 # Main-thread required
 [Microsoft.Internal.VisualStudio.Shell.Interop.*]
 [Microsoft.VisualStudio.OLE.Interop.*]
 [Microsoft.VisualStudio.Shell.Interop.*]
 [Microsoft.VisualStudio.Shell.Package]::GetService
-[Microsoft.VisualStudio.Shell.ServiceProvider]
+[Microsoft.VisualStudio.Shell.ServiceProvider]::CreateFromSetSite
 [Microsoft.VisualStudio.Shell.UIContext]::IsActive
 [EnvDTE.*]
 [EnvDTE80.*]
@@ -158,5 +161,3 @@
 ![Microsoft.VisualStudio.Shell.Interop.SVsThreadedWaitDialogFactory]
 ![Microsoft.VisualStudio.Shell.Interop.IVsUIContextMonitor]
 ![Microsoft.VisualStudio.Shell.Interop.SVsUIContextMonitor]
-![Microsoft.VisualStudio.Shell.ServiceProvider]::GlobalProvider
-![Microsoft.VisualStudio.Shell.ServiceProvider]::GetGlobalServiceAsync


### PR DESCRIPTION
ServiceProvider is free-threaded except for CreateFromSetSite, so remove outright ban of it.

This also also addressed the issue where GetGlobalServiceAsync/GlobalProvider were being classed as main thread because the type was overruling their designations, so added a comment to call that out scenario if we encounter again.

This worked as expected:

<img width="752" alt="image" src="https://github.com/microsoft/VSSDK-Analyzers/assets/1103906/96930459-1f8a-4be7-aa00-c9811b009c36">
