### PR TITLE
Bump Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit to 1.1.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces" Version="17.8.36938" />

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer.cs
@@ -63,61 +63,51 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
 
             // Register for compilation first so that we only activate the analyzer for applicable compilations
-            context.RegisterCompilationStartAction(compilationContext =>
+            context.RegisterCompilationStartAction(context =>
             {
-                INamedTypeSymbol? packageType = compilationContext.Compilation.GetTypeByMetadataName(Types.Package.FullName)?.OriginalDefinition;
-                INamedTypeSymbol? asyncPackageType = compilationContext.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName)?.OriginalDefinition;
+                INamedTypeSymbol? packageType = context.Compilation.GetTypeByMetadataName(Types.Package.FullName)?.OriginalDefinition;
+                INamedTypeSymbol? asyncPackageType = context.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName)?.OriginalDefinition;
+                INamedTypeSymbol? packageRegistrationType = context.Compilation.GetTypeByMetadataName(Types.PackageRegistrationAttribute.FullName);
                 if (packageType != null && asyncPackageType != null)
                 {
-                    // Reuse the type symbols we looked up so that we don't have to look them up for every single class declaration.
-                    compilationContext.RegisterSyntaxNodeAction(
-                        Utils.DebuggableWrapper(ctxt => this.AnalyzeClassDeclaration(ctxt, packageType, asyncPackageType)),
-                        SyntaxKind.ClassDeclaration);
+                    context.RegisterSymbolAction(
+                        Utils.DebuggableWrapper((SymbolAnalysisContext context) =>
+                        {
+                            INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+                            if (namedTypeSymbol.BaseType is null || !Utils.IsEqualToOrDerivedFrom(namedTypeSymbol.BaseType, packageType))
+                            {
+                                return;
+                            }
+
+                            AttributeData? packageRegistrationInstance = namedTypeSymbol.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, packageRegistrationType));
+                            if (packageRegistrationInstance is null)
+                            {
+                                return;
+                            }
+
+                            if (!(packageRegistrationInstance.NamedArguments.FirstOrDefault(kv => kv.Key == Types.PackageRegistrationAttribute.AllowsBackgroundLoading).Value.Value is bool allowsBackgroundLoading))
+                            {
+                                allowsBackgroundLoading = false;
+                            }
+
+                            bool isAsyncPackageBaseType = Utils.IsEqualToOrDerivedFrom(namedTypeSymbol.BaseType, asyncPackageType);
+                            if (isAsyncPackageBaseType != allowsBackgroundLoading)
+                            {
+                                // We have a problem. Use the syntax analyzer to find the location to report.
+                                var attributeSyntax = packageRegistrationInstance.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) as AttributeSyntax;
+                                if (attributeSyntax is object)
+                                {
+                                    AttributeArgumentSyntax? allowBackgroundLoadingSyntax = attributeSyntax.ArgumentList?.Arguments.FirstOrDefault(a => a.NameEquals?.Name?.Identifier.Text == Types.PackageRegistrationAttribute.AllowsBackgroundLoading);
+                                    Location location = allowBackgroundLoadingSyntax?.GetLocation() ?? attributeSyntax.GetLocation();
+                                    ImmutableDictionary<string, string?> properties = ImmutableDictionary.Create<string, string?>()
+                                        .Add(BaseTypeDiagnosticPropertyName, isAsyncPackageBaseType ? Types.AsyncPackage.TypeName : Types.Package.TypeName);
+                                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, properties));
+                                }
+                            }
+                        }),
+                        SymbolKind.NamedType);
                 }
             });
-        }
-
-        private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol packageType, INamedTypeSymbol asyncPackageType)
-        {
-            var declaration = (ClassDeclarationSyntax)context.Node;
-            BaseTypeSyntax? baseType = declaration.BaseList?.Types.FirstOrDefault();
-            if (baseType == null)
-            {
-                return;
-            }
-
-            var baseTypeSymbol = context.SemanticModel.GetSymbolInfo(baseType.Type, context.CancellationToken).Symbol?.OriginalDefinition as ITypeSymbol;
-
-            if (Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, packageType))
-            {
-                INamedTypeSymbol? packageRegistrationType = context.Compilation.GetTypeByMetadataName(Types.PackageRegistrationAttribute.FullName);
-                INamedTypeSymbol? userClassSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
-                AttributeData? packageRegistrationInstance = userClassSymbol?.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, packageRegistrationType));
-                if (packageRegistrationInstance == null)
-                {
-                    return;
-                }
-
-                if (!(packageRegistrationInstance.NamedArguments.FirstOrDefault(kv => kv.Key == Types.PackageRegistrationAttribute.AllowsBackgroundLoading).Value.Value is bool allowsBackgroundLoading))
-                {
-                    allowsBackgroundLoading = false;
-                }
-
-                bool isAsyncPackageBaseType = Utils.IsEqualToOrDerivedFrom(baseTypeSymbol, asyncPackageType);
-
-                if (isAsyncPackageBaseType != allowsBackgroundLoading)
-                {
-                    var attributeSyntax = packageRegistrationInstance.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) as AttributeSyntax;
-                    if (attributeSyntax is object)
-                    {
-                        AttributeArgumentSyntax? allowBackgroundLoadingSyntax = attributeSyntax.ArgumentList?.Arguments.FirstOrDefault(a => a.NameEquals?.Name?.Identifier.Text == Types.PackageRegistrationAttribute.AllowsBackgroundLoading);
-                        Location location = allowBackgroundLoadingSyntax?.GetLocation() ?? attributeSyntax.GetLocation();
-                        ImmutableDictionary<string, string?> properties = ImmutableDictionary.Create<string, string?>()
-                            .Add(BaseTypeDiagnosticPropertyName, isAsyncPackageBaseType ? Types.AsyncPackage.TypeName : Types.Package.TypeName);
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, properties));
-                    }
-                }
-            }
         }
     }
 }

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -16,10 +16,10 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TCodeFix : CodeFixProvider, new()
 {
     public static DiagnosticResult Diagnostic()
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
 
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
         => new DiagnosticResult(descriptor);

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageAnalyzerTests.cs
@@ -12,7 +12,7 @@ public class VSSDK001DeriveFromAsyncPackageAnalyzerTests
     [Fact]
     public async Task AsyncPackageDerivedClassProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : AsyncPackage {
@@ -25,7 +25,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task NoBaseTypeProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 class Test {
 }
 ";
@@ -36,7 +36,7 @@ class Test {
     [Fact]
     public async Task PackageDerivedClassProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : Package {
@@ -50,7 +50,7 @@ class Test : Package {
     [Fact]
     public async Task PackageDerivedClassWithInterfacesProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using Microsoft.VisualStudio.Shell;
 

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -12,14 +12,14 @@ public class VSSDK001DeriveFromAsyncPackageCodeFixTests
     [Fact]
     public async Task BaseTypeChangesToAsyncPackageAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : [|Package|]
 {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : AsyncPackage
@@ -32,7 +32,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task PackageRegistrationUpdated_NewArgumentAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true)]
@@ -40,7 +40,7 @@ class Test : [|Package|]
 {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
@@ -54,7 +54,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task PackageRegistrationUpdated_ExistingArgumentAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = false)]
@@ -62,7 +62,7 @@ class Test : [|Package|]
 {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
@@ -76,7 +76,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task BaseTypeChangesToAsyncPackage_WithInterfacesAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using Microsoft.VisualStudio.Shell;
 
@@ -87,7 +87,7 @@ class Test : [|Package|], IDisposable
     }
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using System;
 using Microsoft.VisualStudio.Shell;
 
@@ -104,12 +104,12 @@ class Test : AsyncPackage, IDisposable
     [Fact]
     public async Task BaseTypeChangesToAsyncPackage_NoUsingsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 class Test : [|Microsoft.VisualStudio.Shell.Package|]
 {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : AsyncPackage
@@ -122,7 +122,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task BaseTypeChangesToAsyncPackage_NoUsings_AndInitializeMethod()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 class Test : [|Microsoft.VisualStudio.Shell.Package|]
 {
     protected override void Initialize()
@@ -131,7 +131,7 @@ class Test : [|Microsoft.VisualStudio.Shell.Package|]
     }
 }
 ";
-        var withFix = @"using System;
+        var withFix = /* lang=c#-test */ @"using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
@@ -155,7 +155,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task BaseTypeChangesToAsyncPackage_InPartiallyMatchingNamespaceAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 namespace Microsoft.VisualStudio
 {
     class Test : [|Microsoft.VisualStudio.Shell.Package|]
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio
     }
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio
     [Fact]
     public async Task BaseTypeChangesToAsyncPackage_InPartiallyMatchingNamespace_UsingsInsideNamespace()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 namespace Microsoft.VisualStudio
 {
     using System;
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio
     }
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 namespace Microsoft.VisualStudio
 {
     using System;
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio
     [Fact]
     public async Task InitializeOverride_BecomesAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 namespace NS
 {
     using System;
@@ -226,7 +226,7 @@ namespace NS
     }
 }
 ";
-        var withFix = @"using Task = System.Threading.Tasks.Task;
+        var withFix = /* lang=c#-test */ @"using Task = System.Threading.Tasks.Task;
 
 namespace NS
 {
@@ -258,7 +258,7 @@ namespace NS
     [Fact]
     public async Task InitializeOverride_AlreadyDefinesTaskUsing()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using Task = System.Threading.Tasks.Task;
 
@@ -270,7 +270,7 @@ class Test : [|Microsoft.VisualStudio.Shell.Package|]
     }
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -295,7 +295,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task InitializeOverride_MissingBaseInitializeCall()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 
 class Test : [|Microsoft.VisualStudio.Shell.Package|]
@@ -306,7 +306,7 @@ class Test : [|Microsoft.VisualStudio.Shell.Package|]
     }
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -330,7 +330,7 @@ class Test : AsyncPackage
     [Fact]
     public async Task InitializeOverride_GetServiceCallsUpdatedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -347,7 +347,7 @@ class Test : [|Package|]
     }
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Threading.Tasks;
 using Xunit;
 using Verify = CSharpCodeFixVerifier<
     Microsoft.VisualStudio.SDK.Analyzers.VSSDK002PackageRegistrationMatchesBaseTypeAnalyzer,
@@ -12,7 +11,7 @@ public class VSSDK002PackageRegistrationMatchesBaseTypeAnalyzerTests
     [Fact]
     public async Task AsyncPackageWithNoAttributeProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : AsyncPackage {
@@ -25,7 +24,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task PackageRegistrationWithNoBaseTypeAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true)]
@@ -39,7 +38,7 @@ class Test {
     [Fact]
     public async Task PackageRegistrationWithIrrelevantAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using Microsoft.VisualStudio.Shell;
 
@@ -55,7 +54,7 @@ class Test : IDisposable {
     [Fact]
     public async Task AsyncPackageMatchProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
@@ -69,7 +68,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task PackageMatchProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true)]
@@ -83,14 +82,14 @@ class MyCoolPackage : Package {
     [Fact]
     public async Task AsyncPackageImplicitMismatchProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [[|PackageRegistration(UseManagedResourcesOnly = true)|]]
 class Test : AsyncPackage {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
@@ -104,7 +103,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task AsyncPackageImplicitMismatchViaIntermediateClass_ProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Middle : AsyncPackage { }
@@ -113,7 +112,7 @@ class Middle : AsyncPackage { }
 class Test : Middle {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Middle : AsyncPackage { }
@@ -129,7 +128,7 @@ class Test : Middle {
     [Fact]
     public async Task PackageMismatchViaIntermediateClass_ProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Middle : Package { }
@@ -138,7 +137,7 @@ class Middle : Package { }
 class MyCoolPackage : Middle {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Middle : Package { }
@@ -154,14 +153,14 @@ class MyCoolPackage : Middle {
     [Fact]
     public async Task AsyncPackageExplicitMismatchProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, [|AllowsBackgroundLoading = false|])]
 class Test : AsyncPackage {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
@@ -175,14 +174,14 @@ class Test : AsyncPackage {
     [Fact]
     public async Task PackageMismatchProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true, [|AllowsBackgroundLoading = true|])]
 class MyCoolPackage : Package {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true)]
@@ -196,14 +195,14 @@ class MyCoolPackage : Package {
     [Fact]
     public async Task PackageMismatchProducesDiagnostic_ReverseArgumentOrderAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration([|AllowsBackgroundLoading = true|], UseManagedResourcesOnly = true)]
 class MyCoolPackage : Package {
 }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [PackageRegistration(UseManagedResourcesOnly = true)]
@@ -217,7 +216,7 @@ class MyCoolPackage : Package {
     [Fact]
     public async Task PackageMismatchProducesDiagnostic_AcrossPartialClassAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 partial class MyCoolPackage : Package {
@@ -226,7 +225,7 @@ partial class MyCoolPackage : Package {
 [PackageRegistration([|AllowsBackgroundLoading = true|], UseManagedResourcesOnly = true)]
 partial class MyCoolPackage { }
 ";
-        var withFix = @"
+        var withFix = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 partial class MyCoolPackage : Package {
@@ -242,7 +241,7 @@ partial class MyCoolPackage { }
     [Fact]
     public async Task PackageMatchViaIntermediateClass_ProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Middle : Package { }
@@ -257,7 +256,7 @@ class Test : Middle {
     [Fact]
     public async Task AsyncPackageMatchViaIntermediateClass_ProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Middle : AsyncPackage { }

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK003SupportAsyncToolWindowAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK003SupportAsyncToolWindowAnalyzerTests.cs
@@ -12,7 +12,7 @@ public class VSSDK003SupportAsyncToolWindowAnalyzerTests
     [Fact]
     public async Task SyncToolWindow_NonAsyncPackage_ProducesDiagnosticAsync()
     {
-        var package = @"
+        var package = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideToolWindow(typeof(ToolWindow1))]
@@ -20,7 +20,7 @@ class ToolWindow1Package : Package
 {
 }
 ";
-        var toolWindow = @"
+        var toolWindow = /* lang=c#-test */ @"
 using System.Runtime.InteropServices;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell;
@@ -48,7 +48,7 @@ public class ToolWindow1 : ToolWindowPane
     [Fact]
     public async Task SyncToolWindow_AsyncPackage_ProducesDiagnosticAsync()
     {
-        var package = @"
+        var package = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideToolWindow(typeof(ToolWindow1))]
@@ -56,7 +56,7 @@ class ToolWindow1Package : AsyncPackage
 {
 }
 ";
-        var toolWindow = @"
+        var toolWindow = /* lang=c#-test */ @"
 using System.Runtime.InteropServices;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell;
@@ -85,7 +85,7 @@ public class ToolWindow1 : ToolWindowPane
     [Fact]
     public async Task AsyncToolWindow_ProducesNoDiagnosticAsync()
     {
-        var package = @"
+        var package = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -124,7 +124,7 @@ class ToolWindow1Package : AsyncPackage
     }
 }
 ";
-        var toolWindow = @"
+        var toolWindow = /* lang=c#-test */ @"
 using System.Runtime.InteropServices;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell;
@@ -157,7 +157,7 @@ public class ToolWindow1 : ToolWindowPane
     [Fact]
     public async Task RTWCompatibleAsyncToolWindow_ProducesNoDiagnosticAsync()
     {
-        var package = @"
+        var package = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -196,7 +196,7 @@ class ToolWindow1Package : AsyncPackage
     }
 }
 ";
-        var toolWindow = @"
+        var toolWindow = /* lang=c#-test */ @"
 using System.Runtime.InteropServices;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell;
@@ -229,7 +229,7 @@ public class ToolWindow1 : ToolWindowPane
     [Fact]
     public async Task NoPackageAttributesAsync()
     {
-        var package = @"
+        var package = /* lang=c#-test */ @"
 public class ProtocolPackage : Microsoft.VisualStudio.Shell.AsyncPackage
 {
 }
@@ -240,7 +240,7 @@ public class ProtocolPackage : Microsoft.VisualStudio.Shell.AsyncPackage
     [Fact]
     public async Task OverriddenGetAsyncToolWindowFactory_ToolWindowWithParameterlessConstructor_ProducesNoDiagnosticAsync()
     {
-        var package = @"
+        var package = /* lang=c#-test */ @"
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -279,7 +279,7 @@ class ToolWindow1Package : ToolkitPackage
 {
 }
 ";
-        var toolWindow = @"
+        var toolWindow = /* lang=c#-test */ @"
 using System.Runtime.InteropServices;
 using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell;

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK004ProvideAutoLoadAttributeAnalyzerTests.cs
@@ -13,7 +13,7 @@ public class VSSDK004ProvideAutoLoadAttributeAnalyzerTests
     [Fact]
     public async Task NoPackageBaseClassProvidesNoDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
@@ -26,7 +26,7 @@ class Test {
     [Fact]
     public async Task NoProvideAutoLoadProducesNoDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 class Test : AsyncPackage {
@@ -38,7 +38,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task BasicProvideAutoLoadProducesDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
@@ -52,7 +52,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task ProvideAutoLoadWithFlagsButNoBackgroundLoadProducesDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.None)]
@@ -66,7 +66,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task MultipleProvideAutoLoadProducesMultipleDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{A184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.None)]
@@ -85,7 +85,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task ProvideAutoLoadWithNamedFlagsButNoBackgroundLoadProducesDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", flags: PackageAutoLoadFlags.None)]
@@ -99,7 +99,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task ProvideAutoLoadWithSkipFlagProducesNoDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.SkipWhenUIContextRulesActive)]
@@ -112,7 +112,7 @@ class Test : Package {
     [Fact]
     public async Task ProvideAutoLoadWithBackgroundLoadFlagProducesNoDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
@@ -125,7 +125,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task ProvideAutoLoadOnPackageWithBackgroundLoadFlagProducesDiagnosticsAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 
 [ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK005UseJoinableTaskContextSingletonAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK005UseJoinableTaskContextSingletonAnalyzerTests.cs
@@ -12,7 +12,7 @@ public class VSSDK005UseJoinableTaskContextSingletonAnalyzerTests
     [Fact]
     public async Task InstantiatingInMethod_ProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Threading;
 
 class Test {
@@ -28,7 +28,7 @@ class Test {
     [Fact]
     public async Task InstantiatingInField_ProducesDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Threading;
 
 class Test {
@@ -42,7 +42,7 @@ class Test {
     [Fact]
     public async Task InstantiatingSimilarlyNamedType_ProducesNoDiagnosticAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 class Test {
     JoinableTaskContext jtc = new JoinableTaskContext();
 }

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
@@ -13,7 +13,7 @@ public class VSSDK006CheckServicesExistAnalyzerTests
     [Fact]
     public async Task LocalAssigned_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -26,7 +26,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -48,7 +48,7 @@ class Test : Package {
     [Fact]
     public async Task LocalAssigned_OleInterop_QueryService_Guid_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -60,7 +60,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -81,7 +81,7 @@ class Test : Package {
     [Fact]
     public async Task LocalAssigned_OleInterop_QueryService_Generic_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -93,7 +93,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -114,7 +114,7 @@ class Test : Package {
     [Fact]
     public async Task LocalAssigned_GetService_ThenUsed_WithNullConditionalAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -133,7 +133,7 @@ class Test : Package {
     [Fact]
     public async Task LocalAssigned_IServiceProvider_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -145,7 +145,7 @@ class Test {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using Microsoft;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -166,7 +166,7 @@ class Test {
     [Fact]
     public async Task LocalDeclarationAssignedWithDirectCast_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -179,7 +179,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -201,7 +201,7 @@ class Test : Package {
     [Fact]
     public async Task LocalDeclarationAssignedWithAsCast_GetServiceAsync_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -217,7 +217,7 @@ class Test : AsyncPackage {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -242,7 +242,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task LocalDeclarationAssignedWithAsCast_GetService_InAsyncPackage_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -258,7 +258,7 @@ class Test : AsyncPackage {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -283,7 +283,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task LocalDeclarationAssignedWithAsCast_GetService_InAsyncPackage_ThenUsed_TwiceAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -305,7 +305,7 @@ class Test : AsyncPackage {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -335,7 +335,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task LocalAssignedWithAsCast_GetServiceAsync_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -352,7 +352,7 @@ class Test : AsyncPackage {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -378,7 +378,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task LocalAssignedWithDirectCast_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -392,7 +392,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -415,7 +415,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -429,7 +429,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -452,7 +452,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedElsewhereAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -469,7 +469,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -495,7 +495,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetServiceAsync_ThenUsedElsewhereAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -515,7 +515,7 @@ class Test : AsyncPackage {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -544,7 +544,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task FieldAssigned_GetServiceAsync_WithConfigureAwait_ThenUsedElsewhereAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -564,7 +564,7 @@ class Test : AsyncPackage {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft;
@@ -593,7 +593,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedElsewhereWithIfCheckAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -618,7 +618,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedElsewhereWithIfEqualCheckAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -644,7 +644,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedElsewhereWithIfIsNullCheckAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -670,7 +670,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedElsewhereWithIfIsObjectCheckAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -695,7 +695,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_GetService_ThenUsedElsewhereWithIfIsExpectedTypeCheckAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -720,7 +720,7 @@ class Test : Package {
     [Fact]
     public async Task PropertyAssigned_GetService_ThenUsedWithinClassAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -737,7 +737,7 @@ class Test : Package {
 }
 ";
 
-        var fix = @"
+        var fix = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -763,7 +763,7 @@ class Test : Package {
     [Fact]
     public async Task GetService_DirectlyUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -782,7 +782,7 @@ class Test : Package {
     [Fact]
     public async Task GetService_DirectlyUsed_WithConditionalMemberAccessAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -800,7 +800,7 @@ class Test : Package {
     [Fact]
     public async Task GetServiceAsync_DirectlyUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -822,7 +822,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task GetServiceAsync_WithConfigureAwait_DirectlyUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -844,7 +844,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task GetServiceAsync_WithConfigureAwait()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -865,7 +865,7 @@ class Test : AsyncPackage {
     [Fact]
     public async Task LocalAssigned_CheckedByThrow_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -885,7 +885,7 @@ class Test : Package {
     [Fact]
     public async Task LocalAssigned_CheckedByIf_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -906,7 +906,7 @@ class Test : Package {
     [Fact]
     public async Task LocalAssigned_CheckedByIfIsNotNull_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -927,7 +927,7 @@ class Test : Package {
     [Fact]
     public async Task FieldAssigned_Checked_GetService_ThenUsedAsync()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -948,7 +948,7 @@ class Test : Package {
     [Fact]
     public async Task PartialClass()
     {
-        var test1 = @"
+        var test1 = /* lang=c#-test */ @"
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -963,7 +963,7 @@ partial class Test : Package {
     }
 }
 ";
-        var test2 = @"
+        var test2 = /* lang=c#-test */ @"
 using System;
 
 partial class Test {
@@ -979,7 +979,7 @@ partial class Test {
     [Fact]
     public async Task PartialWithMemberThatChecksOtherField()
     {
-        var test1 = @"
+        var test1 = /* lang=c#-test */ @"
 internal partial class Host {
     private static object s_lockObject = new object();
 
@@ -991,7 +991,7 @@ internal partial class Host {
     }
 }
 ";
-        var test2 = @"
+        var test2 = /* lang=c#-test */ @"
 using System;
 internal partial class Host {
     private static T GetServiceObject<T>(IServiceProvider serviceProvider)

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK007ThreadHelperJTFRunAsyncTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK007ThreadHelperJTFRunAsyncTests.cs
@@ -13,7 +13,7 @@ public class VSSDK007ThreadHelperJTFRunAsyncTests
     [Fact]
     public async Task RunAsync_Dropped_Warning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 namespace ConsoleApplication1
 {
@@ -36,7 +36,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_Forget_Warning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 namespace ConsoleApplication1
@@ -60,7 +60,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_FileAndForget_Warning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 namespace ConsoleApplication1
@@ -84,7 +84,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_Awaited_NoWarning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
@@ -109,7 +109,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_Joined_NoWarning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
@@ -134,7 +134,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_AssignedButNotJoined_Warning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
@@ -215,7 +215,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_AssignedAndJoined_NoWarning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
@@ -259,7 +259,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_JoinedElsewhere_NoWarning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
@@ -369,7 +369,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_Dropped_NotThreadHelper_NoWarning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 namespace ConsoleApplication1
@@ -408,7 +408,7 @@ namespace ConsoleApplication1
     [Fact]
     public async Task RunAsync_DifferentType_NoWarning()
     {
-        var test = @"
+        var test = /* lang=c#-test */ @"
 using System.Threading.Tasks;
 namespace ConsoleApplication1
 {


### PR DESCRIPTION
The version bump appeases a component governance issue.
That bump in the test framework catches a new error in our analyzer, which I fix.
I also take opportunity to activate C# syntax highlighting inside the tests.