### PR TITLE
Stop VSSDK008 acting on IFieldReferenceOperation

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK008ThreadAffinitizedMEFConstruction.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK008ThreadAffinitizedMEFConstruction.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                 // The member itself has an export attribute. Analyzer applies, there's no need to check the containing type.
             }
             else if ((exportAttributeType is not null && !containingType.GetAttributes().Any(attr => Utils.IsEqualToOrDerivedFrom(attr.AttributeClass, exportAttributeType)))
-                || (mef2ExportAttributeType is not null && !containingType.GetAttributes().Any(attr => Utils.IsEqualToOrDerivedFrom(attr.AttributeClass, mef2ExportAttributeType))))
+                && (mef2ExportAttributeType is not null && !containingType.GetAttributes().Any(attr => Utils.IsEqualToOrDerivedFrom(attr.AttributeClass, mef2ExportAttributeType))))
             {
                 // It looks like this type is not a MEF part, so try to return early without checking it.
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK008ThreadAffinitizedMEFConstruction.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK008ThreadAffinitizedMEFConstruction.cs
@@ -85,7 +85,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                         mef2OnPartImportsSatisfiedAttribute)),
                     OperationKind.MethodReference,
                     OperationKind.InstanceReference,
-                    OperationKind.FieldReference,
                     OperationKind.ObjectOrCollectionInitializer,
                     OperationKind.Invocation, // Method calls
                     OperationKind.MemberInitializer, // For static member access
@@ -195,7 +194,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                 return operation switch
                 {
                     IInvocationOperation op => op.TargetMethod,
-                    IFieldReferenceOperation op => op.Field,
                     IPropertyReferenceOperation op => op.Property,
                     IMethodReferenceOperation op => op.Method,
                     IObjectCreationOperation op => op.Constructor,

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFiles/vs-threading.MainThreadAssertingMethods.mocks.txt
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFiles/vs-threading.MainThreadAssertingMethods.mocks.txt
@@ -1,3 +1,4 @@
 [Microsoft.VisualStudio.Shell.UIContext]
 [Microsoft.VisualStudio.Shell.ThreadHelper]::ThrowIfNotOnUIThread
 [Microsoft.VisualStudio.Threading.JoinableTaskFactory]::SwitchToMainThreadAsync
+[Microsoft.VisualStudio.Shell.TaskListItem]

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -66,7 +66,7 @@ public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         private static readonly ReferenceAssemblies DefaultReferences = ReferenceAssemblies.NetFramework.Net472.Wpf;
         private static readonly ReferenceAssemblies VsSdkReferences = DefaultReferences
             .AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Microsoft.VisualStudio.Shell.15.0", "16.5.29911.84")));
+                new PackageIdentity("Microsoft.VisualStudio.Shell.15.0", "17.12.40392")));
 
         static Test()
         {

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK001DeriveFromAsyncPackageCodeFixTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Threading.Tasks;
 using Xunit;
 using Verify = CSharpCodeFixVerifier<
     Microsoft.VisualStudio.SDK.Analyzers.VSSDK001DeriveFromAsyncPackageAnalyzer,
@@ -232,11 +231,12 @@ namespace NS
 {
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.Shell;
 
     class Test : AsyncPackage
     {
-        protected override async System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             Console.WriteLine(""before"");
 

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK008ThreadAffinitizedMEFConstructionTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK008ThreadAffinitizedMEFConstructionTests.cs
@@ -460,7 +460,7 @@ class C
     }
 
     [Fact]
-    public async Task FieldInitializer_Benign_NoWarning()
+    public async Task FieldAccess_NoWarning()
     {
         var test = /* lang=c#-test */ @"
 using System.ComponentModel.Composition;
@@ -468,7 +468,7 @@ using System.ComponentModel.Composition;
 [Export]
 class C
 {
-    object o = new object();
+    object o = Microsoft.VisualStudio.Shell.TaskListItem.contextNameKeyword;
 
     public C()
     {

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK008ThreadAffinitizedMEFConstructionTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK008ThreadAffinitizedMEFConstructionTests.cs
@@ -570,8 +570,6 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Utilities;
 
 [Export]
-[Name(PartName)]
-[Order(Before = ""default"")]
 internal class C
 {
     public const string PartName = ""PartName"";


### PR DESCRIPTION
Recent insertion of VSSDK-Analyzers to VS produced warnings when using benign consts. The analyzer should not act on `IFieldReferenceOperation`.

This PR:
- Stops acting on `IFieldReferenceOperation`
- Adds test case where a field access (to a const string) is made
  - To get access to a const, I had to update Shell dependency to version 17.12, and I needed to make a few adjustments to support this.