### PR TITLE
KeyBindingHelper requires the main thread

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt
@@ -3,6 +3,7 @@
 
 # Main-thread required
 [Microsoft.Internal.VisualStudio.Shell.Interop.*]
+[Microsoft.Internal.VisualStudio.Shell.KeyBindingHelper]
 [Microsoft.VisualStudio.OLE.Interop.*]
 [Microsoft.VisualStudio.Shell.Interop.*]
 [Microsoft.VisualStudio.Shell.Package]::GetService


### PR DESCRIPTION
It uses `DTE.Commands` to determine the keyboard shortcut used for a given command. This requires the main thread. Annotating this fact here can prevent hangs (ask me how I know).