### PR TITLE
Add VSSDK009 analyzer to flag non-UI thread related `VsTaskRunContext` arguments

### DIFF
--- a/doc/VSSDK009.md
+++ b/doc/VSSDK009.md
@@ -1,0 +1,46 @@
+# VSSDK009 Use approved `VsTaskRunContext` values with `VsTaskLibraryHelper`
+
+`Microsoft.VisualStudio.Shell.VsTaskLibraryHelper` helpers such as `StartOnIdle`, `RunAsync`, and `WithPriority` schedule work on the UI thread or influence the priority used when switching to it.
+Only these `VsTaskRunContext` values are allowed:
+
+- `VsTaskRunContext.UIThreadBackgroundPriority`
+- `VsTaskRunContext.UIThreadIdlePriority`
+- `VsTaskRunContext.UIThreadNormalPriority`
+
+## Examples of patterns that are flagged by this analyzer
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class MyPackage
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.StartOnIdle(() => { }, VsTaskRunContext.BackgroundThread);
+        joinableTaskFactory.RunAsync(VsTaskRunContext.CurrentContext, async () => await Task.Yield());
+        joinableTaskFactory.WithPriority(VsTaskRunContext.UIThreadSend);
+    }
+}
+```
+
+## Solution
+
+Use one of the approved values instead.
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class MyPackage
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.StartOnIdle(() => { }, VsTaskRunContext.UIThreadBackgroundPriority);
+        joinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, async () => await Task.Yield());
+        joinableTaskFactory.WithPriority(VsTaskRunContext.UIThreadIdlePriority);
+    }
+}
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -13,6 +13,7 @@ ID | Title | Category
 [VSSDK006](VSSDK006.md) | Check service exists | Reliability
 [VSSDK007](VSSDK007.md) | Avoid ThreadHelper for fire and forget tasks | Reliability
 [VSSDK008](VSSDK008.md) | Avoid UI thread in MEF Part construction | Reliability
+[VSSDK009](VSSDK009.md) | Use approved VsTaskRunContext values with VsTaskLibraryHelper | Reliability
 
 This analyzer package also depends on the [Microsoft.VisualStudio.Threading.Analyzers][2] package, which adds [many more analyzers][3].
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@ VSSDK005 | Reliability | Error | VSSDK005UseJoinableTaskContextSingletonAnalyzer
 VSSDK006 | Reliability | Warning | VSSDK006CheckServicesExistAnalyzer
 VSSDK007 | Reliability | Warning | VSSDK007ThreadHelperJTFRunAsync
 VSSDK008 | Reliability | Warning | VSSDK008ThreadAffinitizedMEFConstruction
+VSSDK009 | Reliability | Error | VSSDK009UseUIThreadVsTaskRunContextAnalyzer

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -470,6 +470,78 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         }
 
         /// <summary>
+        /// Describes the "Shell.VsTaskLibraryHelper" type.
+        /// </summary>
+        internal static class VsTaskLibraryHelper
+        {
+            /// <summary>
+            /// Gets the simple name of the "Shell.VsTaskLibraryHelper" type.
+            /// </summary>
+            internal const string TypeName = "VsTaskLibraryHelper";
+
+            /// <summary>
+            /// The name of the "Shell.VsTaskLibraryHelper.StartOnIdle" method.
+            /// </summary>
+            internal const string StartOnIdle = "StartOnIdle";
+
+            /// <summary>
+            /// The name of the "Shell.VsTaskLibraryHelper.RunAsync" method.
+            /// </summary>
+            internal const string RunAsync = "RunAsync";
+
+            /// <summary>
+            /// The name of the "Shell.VsTaskLibraryHelper.WithPriority" method.
+            /// </summary>
+            internal const string WithPriority = "WithPriority";
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
+        /// Describes the "Shell.VsTaskRunContext" type.
+        /// </summary>
+        internal static class VsTaskRunContext
+        {
+            /// <summary>
+            /// Gets the simple name of the "Shell.VsTaskRunContext" type.
+            /// </summary>
+            internal const string TypeName = "VsTaskRunContext";
+
+            /// <summary>
+            /// The name of the "Shell.VsTaskRunContext.UIThreadBackgroundPriority" enum value.
+            /// </summary>
+            internal const string UIThreadBackgroundPriority = nameof(UIThreadBackgroundPriority);
+
+            /// <summary>
+            /// The name of the "Shell.VsTaskRunContext.UIThreadIdlePriority" enum value.
+            /// </summary>
+            internal const string UIThreadIdlePriority = nameof(UIThreadIdlePriority);
+
+            /// <summary>
+            /// The name of the "Shell.VsTaskRunContext.UIThreadNormalPriority" enum value.
+            /// </summary>
+            internal const string UIThreadNormalPriority = nameof(UIThreadNormalPriority);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
         /// Describes the "Shell.PackageRegistrationAttribute" type.
         /// </summary>
         internal static class PackageRegistrationAttribute

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK009UseUIThreadVsTaskRunContextAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK009UseUIThreadVsTaskRunContextAnalyzer.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.VisualStudio.SDK.Analyzers;
+
+/// <summary>
+/// Reports incorrect <see cref="Types.VsTaskRunContext"/> values passed to selected <see cref="Types.VsTaskLibraryHelper"/> methods.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class VSSDK009UseUIThreadVsTaskRunContextAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+    /// </summary>
+    public const string Id = "VSSDK009";
+
+    /// <summary>
+    /// A reusable descriptor for diagnostics produced by this analyzer.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Descriptor = new(
+        id: Id,
+        title: "Use approved VsTaskRunContext values with VsTaskLibraryHelper",
+        messageFormat: "Use VsTaskRunContext.UIThreadBackgroundPriority, VsTaskRunContext.UIThreadIdlePriority, or VsTaskRunContext.UIThreadNormalPriority when calling VsTaskLibraryHelper.{0}",
+        description: "VsTaskLibraryHelper.StartOnIdle and priority-related VsTaskLibraryHelper helpers should use VsTaskRunContext.UIThreadBackgroundPriority, VsTaskRunContext.UIThreadIdlePriority, or VsTaskRunContext.UIThreadNormalPriority.",
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDiagnostics = ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDiagnostics;
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+        context.RegisterCompilationStartAction(start =>
+        {
+            INamedTypeSymbol? vsTaskLibraryHelper = start.Compilation.GetTypeByMetadataName(Types.VsTaskLibraryHelper.FullName);
+            INamedTypeSymbol? vsTaskRunContext = start.Compilation.GetTypeByMetadataName(Types.VsTaskRunContext.FullName);
+            if (vsTaskLibraryHelper is not null && vsTaskRunContext is not null)
+            {
+                start.RegisterOperationAction(
+                    Utils.DebuggableWrapper(ctxt => AnalyzeInvocation(ctxt, vsTaskLibraryHelper, vsTaskRunContext)),
+                    OperationKind.Invocation);
+            }
+        });
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol vsTaskLibraryHelper, INamedTypeSymbol vsTaskRunContext)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        IMethodSymbol invokedMethod = invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod;
+        if (!SymbolEqualityComparer.Default.Equals(invokedMethod.ContainingType, vsTaskLibraryHelper) ||
+            !IsTrackedVsTaskLibraryHelperMethod(invokedMethod.Name))
+        {
+            return;
+        }
+
+        IArgumentOperation? priorityArgument = invocation.Arguments.FirstOrDefault(arg => SymbolEqualityComparer.Default.Equals(arg.Parameter?.Type, vsTaskRunContext));
+        if (priorityArgument is null || !IsDisallowedVsTaskRunContextValue(priorityArgument.Value, vsTaskRunContext))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, priorityArgument.Syntax.GetLocation(), invokedMethod.Name));
+    }
+
+    private static bool IsTrackedVsTaskLibraryHelperMethod(string methodName)
+    {
+        return methodName is Types.VsTaskLibraryHelper.StartOnIdle or Types.VsTaskLibraryHelper.RunAsync or Types.VsTaskLibraryHelper.WithPriority;
+    }
+
+    private static bool IsDisallowedVsTaskRunContextValue(IOperation operation, INamedTypeSymbol vsTaskRunContext)
+    {
+        bool sawVsTaskRunContextField = false;
+
+        foreach (IFieldReferenceOperation fieldReference in operation.DescendantsAndSelf().OfType<IFieldReferenceOperation>())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(fieldReference.Field.ContainingType, vsTaskRunContext))
+            {
+                continue;
+            }
+
+            sawVsTaskRunContextField = true;
+            if (fieldReference.Field.Name is Types.VsTaskRunContext.UIThreadBackgroundPriority or Types.VsTaskRunContext.UIThreadIdlePriority or Types.VsTaskRunContext.UIThreadNormalPriority)
+            {
+                return false;
+            }
+        }
+
+        return sawVsTaskRunContextField;
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK009UseUIThreadVsTaskRunContextAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK009UseUIThreadVsTaskRunContextAnalyzerTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = CSharpCodeFixVerifier<
+    Microsoft.VisualStudio.SDK.Analyzers.VSSDK009UseUIThreadVsTaskRunContextAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSSDK009UseUIThreadVsTaskRunContextAnalyzerTests
+{
+    [Fact]
+    public async Task StartOnIdleWithBackgroundThreadPriorityProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.StartOnIdle(() => { }, {|#0:VsTaskRunContext.BackgroundThread|});
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("StartOnIdle"));
+    }
+
+    [Fact]
+    public async Task RunAsyncWithBackgroundThreadPriorityProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.RunAsync({|#0:VsTaskRunContext.BackgroundThread|}, async () => await Task.Yield());
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("RunAsync"));
+    }
+
+    [Fact]
+    public async Task WithPriorityWithCurrentContextProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.WithPriority({|#0:VsTaskRunContext.CurrentContext|});
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("WithPriority"));
+    }
+
+    [Fact]
+    public async Task WithPriorityWithUIThreadSendProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.WithPriority({|#0:VsTaskRunContext.UIThreadSend|});
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("WithPriority"));
+    }
+
+    [Fact]
+    public async Task StartOnIdleWithAllowedPriorityProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.StartOnIdle(() => { }, VsTaskRunContext.UIThreadBackgroundPriority);
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RunAsyncWithAllowedPriorityProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, async () => await Task.Yield());
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task StaticStartOnIdleWithCurrentContextProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        VsTaskLibraryHelper.StartOnIdle(joinableTaskFactory, () => { }, {|#0:VsTaskRunContext.CurrentContext|});
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("StartOnIdle"));
+    }
+
+    [Fact]
+    public async Task StartOnIdleWithVariablePriorityProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory, VsTaskRunContext priority)
+    {
+        joinableTaskFactory.StartOnIdle(() => { }, priority);
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task WithPriorityWithUIThreadPriorityProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+class Test
+{
+    void M(JoinableTaskFactory joinableTaskFactory)
+    {
+        joinableTaskFactory.WithPriority(VsTaskRunContext.UIThreadNormalPriority);
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
Passing a non-UI thread related `VsTaskRunContext` to any of a few methods on `VsTaskLibraryHelper` leads to an `ArgumentOutOfRangeException` being thrown. Such a bug has been introduced to the product and merged multiple times.