### PR TITLE
Replace regex-based additional files parsing with custom parser

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AdditionalFilesHelpers.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AdditionalFilesHelpers.cs
@@ -21,10 +21,6 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         private static readonly Regex FileNamePatternForMethodsThatAssertMainThread = new Regex(@"^vs-threading\.MainThreadAssertingMethods(\..*)?.txt$", FileNamePatternRegexOptions);
         private static readonly Regex FileNamePatternForMethodsThatSwitchToMainThread = new Regex(@"^vs-threading\.MainThreadSwitchingMethods(\..*)?.txt$", FileNamePatternRegexOptions);
 
-        private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(5);  // Prevent expensive CPU hang in Regex.Match if backtracking occurs due to pathological input (see vs-threading #485).
-        private static readonly Regex NegatableTypeOrMemberReferenceRegex = new Regex(@"^(?<negated>!)?\[(?<typeName>[^\[\]\:]+)+\](?:\:\:(?<memberName>\S+))?\s*$", RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexMatchTimeout);
-        private static readonly char[] QualifiedIdentifierSeparators = new[] { '.' };
-
         /// <summary>
         /// Gets memebers that require main thread, from all available files matching <see cref="FileNamePatternForMembersRequiringMainThread"/>.
         /// </summary>
@@ -44,29 +40,42 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         {
             foreach (string line in ReadAdditionalFiles(analyzerOptions, fileNamePattern, cancellationToken))
             {
-                Match? match = null;
-                try
-                {
-                    match = NegatableTypeOrMemberReferenceRegex.Match(line);
-                }
-                catch (RegexMatchTimeoutException)
-                {
-                    throw new InvalidOperationException($"Regex.Match timeout when parsing line: {line}");
-                }
-
-                if (!match.Success)
+                if (!AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference(line, out bool negated, out ReadOnlyMemory<char> typeNameMemory, out string? memberNameValue))
                 {
                     throw new InvalidOperationException($"Parsing error on line: {line}");
                 }
 
-                bool inverted = match.Groups["negated"].Success;
-                string[] typeNameElements = match.Groups["typeName"].Value.Split(QualifiedIdentifierSeparators);
-                string typeName = typeNameElements[typeNameElements.Length - 1];
-                var containingNamespace = typeNameElements.Take(typeNameElements.Length - 1).ToImmutableArray();
+                (ImmutableArray<string> containingNamespace, string typeName) = SplitQualifiedIdentifier(typeNameMemory);
                 var type = new QualifiedType(containingNamespace, typeName);
-                QualifiedMember member = match.Groups["memberName"].Success ? new QualifiedMember(type, match.Groups["memberName"].Value) : default(QualifiedMember);
-                yield return new TypeMatchSpec(type, member, inverted);
+                QualifiedMember member = memberNameValue is not null ? new QualifiedMember(type, memberNameValue) : default(QualifiedMember);
+                yield return new TypeMatchSpec(type, member, negated);
             }
+        }
+
+        private static (ImmutableArray<string> ContainingNamespace, string TypeName) SplitQualifiedIdentifier(ReadOnlyMemory<char> qualifiedName)
+        {
+            ReadOnlySpan<char> qualifiedNameSpan = qualifiedName.Span;
+            int lastDot = qualifiedNameSpan.LastIndexOf('.');
+            if (lastDot < 0)
+            {
+                return (ImmutableArray<string>.Empty, qualifiedName.ToString());
+            }
+
+            string typeName = qualifiedName.Slice(lastDot + 1).ToString();
+            ReadOnlySpan<char> namespacePart = qualifiedNameSpan.Slice(0, lastDot);
+            ImmutableArray<string>.Builder namespaceBuilder = ImmutableArray.CreateBuilder<string>();
+
+            int segmentStart = 0;
+            for (int i = 0; i <= namespacePart.Length; i++)
+            {
+                if (i == namespacePart.Length || namespacePart[i] == '.')
+                {
+                    namespaceBuilder.Add(namespacePart.Slice(segmentStart, i - segmentStart).ToString());
+                    segmentStart = i + 1;
+                }
+            }
+
+            return (namespaceBuilder.ToImmutable(), typeName);
         }
 
         private static IEnumerable<string> ReadAdditionalFiles(AnalyzerOptions analyzerOptions, Regex fileNamePattern, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AdditionalFilesParsing.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AdditionalFilesParsing.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.SDK.Analyzers;
+
+/// <summary>
+/// Parsing helpers for additional-file lines used by <see cref="AdditionalFilesHelpers" />.
+/// </summary>
+internal static class AdditionalFilesParsing
+{
+    /// <summary>
+    /// Parses a line that may begin with an optional <c>!</c>, followed by <c>[TypeName]</c>,
+    /// and optionally <c>::MemberName</c>, without using regular expressions.
+    /// </summary>
+    /// <param name="line">The line to parse.</param>
+    /// <param name="negated"><see langword="true" /> if the line begins with <c>!</c>.</param>
+    /// <param name="typeName">The type name parsed from the brackets.</param>
+    /// <param name="memberName">The member name after <c>::</c>, or <see langword="null" /> if not present.</param>
+    /// <returns><see langword="true" /> if parsing succeeded.</returns>
+    internal static bool TryParseNegatableTypeOrMemberReference(string line, out bool negated, out ReadOnlyMemory<char> typeName, out string? memberName)
+    {
+        negated = false;
+        typeName = default;
+        memberName = null;
+
+        ReadOnlySpan<char> span = line.AsSpan();
+        int pos = 0;
+
+        if (pos < span.Length && span[pos] == '!')
+        {
+            negated = true;
+            pos++;
+        }
+
+        int bracketStart = pos;
+        if (!TryParseBracketedTypeName(span, ref pos, out _))
+        {
+            return false;
+        }
+
+        ReadOnlyMemory<char> typeNameMemory = line.AsMemory(bracketStart + 1, pos - bracketStart - 2);
+
+        ReadOnlySpan<char> memberNameSpan = default;
+        if (pos + 1 < span.Length && span[pos] == ':' && span[pos + 1] == ':')
+        {
+            pos += 2;
+            int memberNameStart = pos;
+            while (pos < span.Length && !char.IsWhiteSpace(span[pos]))
+            {
+                pos++;
+            }
+
+            if (pos == memberNameStart)
+            {
+                return false;
+            }
+
+            memberNameSpan = span.Slice(memberNameStart, pos - memberNameStart);
+        }
+
+        while (pos < span.Length && char.IsWhiteSpace(span[pos]))
+        {
+            pos++;
+        }
+
+        if (pos != span.Length)
+        {
+            return false;
+        }
+
+        typeName = typeNameMemory;
+        memberName = memberNameSpan.IsEmpty ? null : memberNameSpan.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a line of the form <c>[TypeName]::MemberName</c>, without using regular expressions.
+    /// </summary>
+    /// <param name="line">The line to parse.</param>
+    /// <param name="typeName">The type name parsed from the brackets.</param>
+    /// <param name="memberName">The member name after <c>::</c>.</param>
+    /// <returns><see langword="true" /> if parsing succeeded.</returns>
+    internal static bool TryParseMemberReference(string line, out ReadOnlyMemory<char> typeName, [NotNullWhen(true)] out string? memberName)
+    {
+        typeName = default;
+        memberName = null;
+
+        ReadOnlySpan<char> span = line.AsSpan();
+        int pos = 0;
+
+        int bracketStart = pos;
+        if (!TryParseBracketedTypeName(span, ref pos, out _))
+        {
+            return false;
+        }
+
+        ReadOnlyMemory<char> typeNameMemory = line.AsMemory(bracketStart + 1, pos - bracketStart - 2);
+
+        if (pos + 1 >= span.Length || span[pos] != ':' || span[pos + 1] != ':')
+        {
+            return false;
+        }
+
+        pos += 2;
+
+        int memberNameStart = pos;
+        while (pos < span.Length && !char.IsWhiteSpace(span[pos]))
+        {
+            pos++;
+        }
+
+        if (pos == memberNameStart)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> memberNameSpan = span.Slice(memberNameStart, pos - memberNameStart);
+
+        while (pos < span.Length && char.IsWhiteSpace(span[pos]))
+        {
+            pos++;
+        }
+
+        if (pos != span.Length)
+        {
+            return false;
+        }
+
+        typeName = typeNameMemory;
+        memberName = memberNameSpan.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// Advances <paramref name="pos" /> past a <c>[TypeName]</c> token and outputs the type-name span.
+    /// </summary>
+    /// <param name="span">The full input span.</param>
+    /// <param name="pos">The current parse position; advanced past the closing <c>]</c> on success.</param>
+    /// <param name="typeName">A slice of <paramref name="span" /> containing the type name, without the brackets.</param>
+    /// <returns><see langword="true" /> if a non-empty bracketed type name was consumed.</returns>
+    internal static bool TryParseBracketedTypeName(ReadOnlySpan<char> span, ref int pos, out ReadOnlySpan<char> typeName)
+    {
+        typeName = default;
+
+        if (pos >= span.Length || span[pos] != '[')
+        {
+            return false;
+        }
+
+        pos++;
+
+        int typeNameStart = pos;
+        while (pos < span.Length && span[pos] != '[' && span[pos] != ']' && span[pos] != ':')
+        {
+            pos++;
+        }
+
+        if (pos == typeNameStart)
+        {
+            return false;
+        }
+
+        typeName = span.Slice(typeNameStart, pos - typeNameStart);
+
+        if (pos >= span.Length || span[pos] != ']')
+        {
+            return false;
+        }
+
+        pos++;
+        return true;
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFilesParsingTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFilesParsingTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.SDK.Analyzers;
+using Xunit;
+
+public class AdditionalFilesParsingTests
+{
+    [Fact]
+    public void TryParseNegatableTypeOrMemberReference_ParsesValidLine()
+    {
+        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference("![My.Namespace.Widget]::Initialize", out bool negated, out ReadOnlyMemory<char> typeName, out string? memberName);
+
+        Assert.True(success);
+        Assert.True(negated);
+        Assert.Equal("My.Namespace.Widget", typeName.ToString());
+        Assert.Equal("Initialize", memberName);
+    }
+
+    [Fact]
+    public void TryParseNegatableTypeOrMemberReference_RejectsMalformedLine()
+    {
+        string malformed = "![[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[";
+
+        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference(malformed, out _, out _, out _);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public void TryParseMemberReference_ParsesValidLine()
+    {
+        bool success = AdditionalFilesParsing.TryParseMemberReference("[My.Namespace.Widget]::Initialize", out ReadOnlyMemory<char> typeName, out string? memberName);
+
+        Assert.True(success);
+        Assert.Equal("My.Namespace.Widget", typeName.ToString());
+        Assert.Equal("Initialize", memberName);
+    }
+
+    [Fact]
+    public void TryParseNegatableTypeOrMemberReference_ParsesTypeOnlyWithTrailingWhitespace()
+    {
+        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference("[My.Namespace.Widget]   \t", out bool negated, out ReadOnlyMemory<char> typeName, out string? memberName);
+
+        Assert.True(success);
+        Assert.False(negated);
+        Assert.Equal("My.Namespace.Widget", typeName.ToString());
+        Assert.Null(memberName);
+    }
+
+    [Fact]
+    public void TryParseNegatableTypeOrMemberReference_RejectsMissingMemberAfterSeparator()
+    {
+        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference("[My.Namespace.Widget]::", out _, out _, out _);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public void TryParseMemberReference_RejectsTypeOnlyLine()
+    {
+        bool success = AdditionalFilesParsing.TryParseMemberReference("[My.Namespace.Widget]", out _, out _);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public void TryParseMemberReference_RejectsNonWhitespaceTrailingCharacters()
+    {
+        bool success = AdditionalFilesParsing.TryParseMemberReference("[My.Namespace.Widget]::Initialize extra", out _, out _);
+
+        Assert.False(success);
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/Microsoft.VisualStudio.SDK.Analyzers.Tests.csproj
@@ -28,6 +28,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Link the parser source directly so tests stay in sync with product code without reflection/InternalsVisibleTo. -->
+    <Compile Include="..\..\src\Microsoft.VisualStudio.SDK.Analyzers\AdditionalFilesParsing.cs"
+      Link="AdditionalFilesParsing.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="PresentationFramework" />
   </ItemGroup>
 


### PR DESCRIPTION
This avoids the high cost of regex and the timeouts we were using to defend against bad inputs.

This is a logical port of microsoft/vs-threading#1547

Fixes devdiv-3036514
