### PR TITLE
Make additional file parsing more resilient

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AdditionalFilesParsing.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AdditionalFilesParsing.cs
@@ -47,7 +47,7 @@ internal static class AdditionalFilesParsing
         {
             pos += 2;
             int memberNameStart = pos;
-            while (pos < span.Length && !char.IsWhiteSpace(span[pos]))
+            while (pos < span.Length && span[pos] != ':' && !char.IsWhiteSpace(span[pos]))
             {
                 pos++;
             }
@@ -106,7 +106,7 @@ internal static class AdditionalFilesParsing
         pos += 2;
 
         int memberNameStart = pos;
-        while (pos < span.Length && !char.IsWhiteSpace(span[pos]))
+        while (pos < span.Length && span[pos] != ':' && !char.IsWhiteSpace(span[pos]))
         {
             pos++;
         }

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFilesParsingTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFilesParsingTests.cs
@@ -48,26 +48,26 @@ public class AdditionalFilesParsingTests
         Assert.Null(memberName);
     }
 
-    [Fact]
-    public void TryParseNegatableTypeOrMemberReference_RejectsMissingMemberAfterSeparator()
+    [Theory]
+    [InlineData("[My.Namespace.Widget]::")]
+    [InlineData("!![My.Namespace.Widget]::Initialize")]
+    [InlineData("[My.Namespace.Widget] ::Initialize")]
+    [InlineData("[My.Namespace.Widget]:Initialize")]
+    [InlineData("[My.Namespace.Widget]:::Initialize")]
+    public void TryParseNegatableTypeOrMemberReference_RejectsMalformedCases(string input)
     {
-        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference("[My.Namespace.Widget]::", out _, out _, out _);
+        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference(input, out _, out _, out _);
 
         Assert.False(success);
     }
 
-    [Fact]
-    public void TryParseMemberReference_RejectsTypeOnlyLine()
+    [Theory]
+    [InlineData("[My.Namespace.Widget]")]
+    [InlineData("[My.Namespace.Widget]::Initialize extra")]
+    [InlineData("[My.Namespace.Widget]:::Initialize")]
+    public void TryParseMemberReference_RejectsMalformedCases(string input)
     {
-        bool success = AdditionalFilesParsing.TryParseMemberReference("[My.Namespace.Widget]", out _, out _);
-
-        Assert.False(success);
-    }
-
-    [Fact]
-    public void TryParseMemberReference_RejectsNonWhitespaceTrailingCharacters()
-    {
-        bool success = AdditionalFilesParsing.TryParseMemberReference("[My.Namespace.Widget]::Initialize extra", out _, out _);
+        bool success = AdditionalFilesParsing.TryParseMemberReference(input, out _, out _);
 
         Assert.False(success);
     }


### PR DESCRIPTION
In https://github.com/microsoft/VSSDK-Analyzers/pull/408#pullrequestreview-4765623832 @sandyarmstrong suggested some improvements. Copilot resolved the comment thread before pushing the fixes so that PR ended up merging before the improvements could be made. So they're in this change instead.