### PR TITLE
Add regression coverage for VSSDK008 regex timeout

### DIFF
--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFilesParsingTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/AdditionalFilesParsingTests.cs
@@ -28,6 +28,16 @@ public class AdditionalFilesParsingTests
     }
 
     [Fact]
+    public void TryParseNegatableTypeOrMemberReference_RejectsInputThatCausesRegexBacktracking()
+    {
+        string malformed = "[" + new string('A', 30);
+
+        bool success = AdditionalFilesParsing.TryParseNegatableTypeOrMemberReference(malformed, out _, out _, out _);
+
+        Assert.False(success);
+    }
+
+    [Fact]
     public void TryParseMemberReference_ParsesValidLine()
     {
         bool success = AdditionalFilesParsing.TryParseMemberReference("[My.Namespace.Widget]::Initialize", out ReadOnlyMemory<char> typeName, out string? memberName);


### PR DESCRIPTION
Malformed threading API-list entries could drive the previous nested-quantifier regex into backtracking until VSSDK008 reported AD0001.

Adds a deterministic malformed type-reference regression case that triggers the historical timeout shape, preserving coverage for the span-based parser that rejects it without regex backtracking.