### PR TITLE
Recognize ternary null checks in VSSDK006

### DIFF
--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
@@ -257,33 +257,41 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
 
             private bool IsDereferenceGuardedByConditionalExpression(MemberAccessExpressionSyntax dereference, ISymbol symbol, SemanticModel semanticModel, CancellationToken cancellationToken)
             {
-                foreach (ConditionalExpressionSyntax conditionalExpression in dereference.Ancestors().OfType<ConditionalExpressionSyntax>())
+                bool? GetConditionValueThatGuaranteesNonNull(ExpressionSyntax condition)
                 {
-                    ExpressionSyntax condition = conditionalExpression.Condition;
                     while (condition is ParenthesizedExpressionSyntax parenthesizedExpression)
                     {
                         condition = parenthesizedExpression.Expression;
                     }
 
                     bool IsSymbol(SyntaxNode node) => SymbolEqualityComparer.Default.Equals(symbol, semanticModel.GetSymbolInfo(node, cancellationToken).Symbol);
-                    bool? nonNullWhenTrue = null;
                     if (condition is BinaryExpressionSyntax binaryExpression)
                     {
+                        if (binaryExpression.IsKind(SyntaxKind.LogicalAndExpression))
+                        {
+                            return GetConditionValueThatGuaranteesNonNull(binaryExpression.Left) == true
+                                || GetConditionValueThatGuaranteesNonNull(binaryExpression.Right) == true
+                                ? true
+                                : (bool?)null;
+                        }
+
                         bool comparesWithNull = (binaryExpression.Left.IsKind(SyntaxKind.NullLiteralExpression) && IsSymbol(binaryExpression.Right))
                             || (binaryExpression.Right.IsKind(SyntaxKind.NullLiteralExpression) && IsSymbol(binaryExpression.Left));
                         if (comparesWithNull && binaryExpression.IsKind(SyntaxKind.EqualsExpression))
                         {
-                            nonNullWhenTrue = false;
+                            return false;
                         }
-                        else if (comparesWithNull && binaryExpression.IsKind(SyntaxKind.NotEqualsExpression))
+
+                        if (comparesWithNull && binaryExpression.IsKind(SyntaxKind.NotEqualsExpression))
                         {
-                            nonNullWhenTrue = true;
+                            return true;
                         }
-                        else if (binaryExpression.OperatorToken.IsKind(SyntaxKind.IsKeyword)
+
+                        if (binaryExpression.OperatorToken.IsKind(SyntaxKind.IsKeyword)
                             && (binaryExpression.Right.IsKind(SyntaxKind.IdentifierName) || binaryExpression.Right.IsKind(SyntaxKind.PredefinedType))
                             && IsSymbol(binaryExpression.Left))
                         {
-                            nonNullWhenTrue = true;
+                            return true;
                         }
                     }
                     else if (condition is IsPatternExpressionSyntax patternExpression && IsSymbol(patternExpression.Expression))
@@ -291,17 +299,23 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                         if (patternExpression.Pattern is ConstantPatternSyntax constantPattern
                             && constantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression))
                         {
-                            nonNullWhenTrue = false;
+                            return false;
                         }
-                        else if (patternExpression.Pattern is UnaryPatternSyntax unaryPattern
+
+                        if (patternExpression.Pattern is UnaryPatternSyntax unaryPattern
                             && unaryPattern.Pattern is ConstantPatternSyntax negatedConstantPattern
                             && negatedConstantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression))
                         {
-                            nonNullWhenTrue = true;
+                            return true;
                         }
                     }
 
-                    ExpressionSyntax? nonNullBranch = nonNullWhenTrue switch
+                    return null;
+                }
+
+                foreach (ConditionalExpressionSyntax conditionalExpression in dereference.Ancestors().OfType<ConditionalExpressionSyntax>())
+                {
+                    ExpressionSyntax? nonNullBranch = GetConditionValueThatGuaranteesNonNull(conditionalExpression.Condition) switch
                     {
                         true => conditionalExpression.WhenTrue,
                         false => conditionalExpression.WhenFalse,

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
@@ -207,7 +207,10 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                         select access;
                     if (!containingBlockOrExpression.DescendantNodes().Any(n => this.IsNonNullCheck(n, symbol, semanticModel, cancellationToken)))
                     {
-                        return variableUses.Select(vu => vu.Expression.GetLocation()).ToImmutableArray();
+                        return variableUses
+                            .Where(vu => !this.IsDereferenceGuardedByConditionalExpression(vu, symbol, semanticModel, cancellationToken))
+                            .Select(vu => vu.Expression.GetLocation())
+                            .ToImmutableArray();
                     }
                 }
 
@@ -229,7 +232,9 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                 bool IsPatternMatchNullCheck(IsPatternExpressionSyntax o) => o.Pattern is ConstantPatternSyntax pattern
                                                                              && pattern.Expression.IsKind(SyntaxKind.NullLiteralExpression)
                                                                              && IsSymbol(o.Expression);
-                bool IsPatternMatchNotNullCheck(IsPatternExpressionSyntax o) => o.Pattern is UnaryPatternSyntax patternSyntax
+                bool IsPatternMatchNotNullCheck(IsPatternExpressionSyntax o) => o.Pattern is UnaryPatternSyntax unaryPattern
+                                                                                && unaryPattern.Pattern is ConstantPatternSyntax pattern
+                                                                                && pattern.Expression.IsKind(SyntaxKind.NullLiteralExpression)
                                                                                 && IsSymbol(o.Expression);
                 bool ContainsNonNullCheck(ExpressionSyntax expression) =>
                     expression.DescendantNodesAndSelf().OfType<BinaryExpressionSyntax>().Any(
@@ -237,8 +242,7 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                     || expression.DescendantNodesAndSelf().OfType<IsPatternExpressionSyntax>().Any(
                         o => IsPatternMatchNullCheck(o) || IsPatternMatchNotNullCheck(o));
 
-                if ((node is IfStatementSyntax ifStatement && ContainsNonNullCheck(ifStatement.Condition))
-                    || (node is ConditionalExpressionSyntax conditionalExpression && ContainsNonNullCheck(conditionalExpression.Condition)))
+                if (node is IfStatementSyntax ifStatement && ContainsNonNullCheck(ifStatement.Condition))
                 {
                     return true;
                 }
@@ -246,6 +250,67 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                 if (this.IsThrowingNullCheck(node, symbol, semanticModel, cancellationToken))
                 {
                     return true;
+                }
+
+                return false;
+            }
+
+            private bool IsDereferenceGuardedByConditionalExpression(MemberAccessExpressionSyntax dereference, ISymbol symbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+            {
+                foreach (ConditionalExpressionSyntax conditionalExpression in dereference.Ancestors().OfType<ConditionalExpressionSyntax>())
+                {
+                    ExpressionSyntax condition = conditionalExpression.Condition;
+                    while (condition is ParenthesizedExpressionSyntax parenthesizedExpression)
+                    {
+                        condition = parenthesizedExpression.Expression;
+                    }
+
+                    bool IsSymbol(SyntaxNode node) => SymbolEqualityComparer.Default.Equals(symbol, semanticModel.GetSymbolInfo(node, cancellationToken).Symbol);
+                    bool? nonNullWhenTrue = null;
+                    if (condition is BinaryExpressionSyntax binaryExpression)
+                    {
+                        bool comparesWithNull = (binaryExpression.Left.IsKind(SyntaxKind.NullLiteralExpression) && IsSymbol(binaryExpression.Right))
+                            || (binaryExpression.Right.IsKind(SyntaxKind.NullLiteralExpression) && IsSymbol(binaryExpression.Left));
+                        if (comparesWithNull && binaryExpression.IsKind(SyntaxKind.EqualsExpression))
+                        {
+                            nonNullWhenTrue = false;
+                        }
+                        else if (comparesWithNull && binaryExpression.IsKind(SyntaxKind.NotEqualsExpression))
+                        {
+                            nonNullWhenTrue = true;
+                        }
+                        else if (binaryExpression.OperatorToken.IsKind(SyntaxKind.IsKeyword)
+                            && (binaryExpression.Right.IsKind(SyntaxKind.IdentifierName) || binaryExpression.Right.IsKind(SyntaxKind.PredefinedType))
+                            && IsSymbol(binaryExpression.Left))
+                        {
+                            nonNullWhenTrue = true;
+                        }
+                    }
+                    else if (condition is IsPatternExpressionSyntax patternExpression && IsSymbol(patternExpression.Expression))
+                    {
+                        if (patternExpression.Pattern is ConstantPatternSyntax constantPattern
+                            && constantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression))
+                        {
+                            nonNullWhenTrue = false;
+                        }
+                        else if (patternExpression.Pattern is UnaryPatternSyntax unaryPattern
+                            && unaryPattern.Pattern is ConstantPatternSyntax negatedConstantPattern
+                            && negatedConstantPattern.Expression.IsKind(SyntaxKind.NullLiteralExpression))
+                        {
+                            nonNullWhenTrue = true;
+                        }
+                    }
+
+                    ExpressionSyntax? nonNullBranch = nonNullWhenTrue switch
+                    {
+                        true => conditionalExpression.WhenTrue,
+                        false => conditionalExpression.WhenFalse,
+                        null => null,
+                    };
+                    if (nonNullBranch?.Span.Contains(dereference.Span) == true)
+                    {
+                        return true;
+                    }
                 }
 
                 return false;

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK006CheckServicesExistAnalyzer.cs
@@ -231,16 +231,16 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
                                                                              && IsSymbol(o.Expression);
                 bool IsPatternMatchNotNullCheck(IsPatternExpressionSyntax o) => o.Pattern is UnaryPatternSyntax patternSyntax
                                                                                 && IsSymbol(o.Expression);
+                bool ContainsNonNullCheck(ExpressionSyntax expression) =>
+                    expression.DescendantNodesAndSelf().OfType<BinaryExpressionSyntax>().Any(
+                        o => IsEqualsOrExclamationEqualsCheck(o) || IsPatternMatchTypeCheck(o))
+                    || expression.DescendantNodesAndSelf().OfType<IsPatternExpressionSyntax>().Any(
+                        o => IsPatternMatchNullCheck(o) || IsPatternMatchNotNullCheck(o));
 
-                if (node is IfStatementSyntax ifStatement)
+                if ((node is IfStatementSyntax ifStatement && ContainsNonNullCheck(ifStatement.Condition))
+                    || (node is ConditionalExpressionSyntax conditionalExpression && ContainsNonNullCheck(conditionalExpression.Condition)))
                 {
-                    if (ifStatement.Condition.DescendantNodesAndSelf().OfType<BinaryExpressionSyntax>().Any(
-                          o => IsEqualsOrExclamationEqualsCheck(o) || IsPatternMatchTypeCheck(o))
-                        || ifStatement.Condition.DescendantNodesAndSelf().OfType<IsPatternExpressionSyntax>().Any(
-                          o => IsPatternMatchNullCheck(o) || IsPatternMatchNotNullCheck(o)))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
 
                 if (this.IsThrowingNullCheck(node, symbol, semanticModel, cancellationToken))

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
@@ -921,6 +921,41 @@ class Test : Package {
     }
 
     [Fact]
+    public async Task LocalAssigned_CheckedByConditionalExpressionWithLogicalAnd_GetService_ThenUsedAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test : Package {
+    private int GetServiceHashCode(bool enabled) {
+        var svc = this.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
+        return svc != null && enabled ? svc.GetHashCode() : 0;
+    }
+}
+";
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task LocalAssigned_CheckedByConditionalExpressionWithLogicalOr_GetService_ThenUsedAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test : Package {
+    private int GetServiceHashCode(bool enabled) {
+        var svc = this.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
+        return svc != null || enabled ? svc.GetHashCode() : 0;
+    }
+}
+";
+        DiagnosticResult expected = this.CreateDiagnostic(7, 19, 15, (7, 13, 3), (8, 41, 3));
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task LocalAssigned_CheckedByConditionalExpression_ThenUsedWithoutCheckAsync()
     {
         var test = /* lang=c#-test */ @"

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
@@ -904,6 +904,23 @@ class Test : Package {
     }
 
     [Fact]
+    public async Task LocalAssigned_CheckedByConditionalExpression_GetService_ThenUsedAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test : Package {
+    private int GetServiceHashCode() {
+        var svc = this.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
+        return svc != null ? svc.GetHashCode() : 0;
+    }
+}
+";
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task LocalAssigned_CheckedByIfIsNotNull_GetService_ThenUsedAsync()
     {
         var test = /* lang=c#-test */ @"

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK006CheckServicesExistAnalyzerTests.cs
@@ -921,6 +921,45 @@ class Test : Package {
     }
 
     [Fact]
+    public async Task LocalAssigned_CheckedByConditionalExpression_ThenUsedWithoutCheckAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test : Package {
+    private void UseService() {
+        var svc = this.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
+        _ = svc != null ? svc.GetHashCode() : 0;
+        svc.BeginDesignTimeBuild();
+    }
+}
+";
+        DiagnosticResult expected = this.CreateDiagnostic(7, 19, 15, (7, 13, 3), (9, 9, 3));
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task LocalAssigned_CheckedByNegatedTypePattern_ThenUsedAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+class Test : Package {
+    private void UseService() {
+        var svc = this.GetService(typeof(SVsBuildManagerAccessor)) as IVsBuildManagerAccessor;
+        if (svc is not object) {
+            svc.GetHashCode();
+        }
+    }
+}
+";
+        DiagnosticResult expected = this.CreateDiagnostic(7, 19, 15, (7, 13, 3), (9, 13, 3));
+        await Verify.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task LocalAssigned_CheckedByIfIsNotNull_GetService_ThenUsedAsync()
     {
         var test = /* lang=c#-test */ @"


### PR DESCRIPTION
VSSDK006 currently reports service results used in a ternary expression even when the ternary condition verifies the result is non-null. Extend the analyzer's existing null-check detection to conditional expressions and add a regression test for the guarded dereference.

Closes #211