### PR TITLE
Add analyzer for redundant package autoloads

### DIFF
--- a/doc/VSSDK010.md
+++ b/doc/VSSDK010.md
@@ -1,0 +1,37 @@
+# VSSDK010 Remove unnecessary `ProvideAutoLoad` attribute
+
+Automatically loading a package has a performance cost. A package that only registers services, code expansions,
+or other declarative contributions does not need to load unless it overrides `Package.Initialize` or
+`AsyncPackage.InitializeAsync`.
+
+This analyzer reports each `ProvideAutoLoad` attribute on a package when neither the package nor an intermediate
+base class overrides the applicable initialization method.
+
+## Example of a pattern that is flagged by this analyzer
+
+```csharp
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}", PackageAutoLoadFlags.BackgroundLoad)]
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class MyPackage : AsyncPackage
+{
+}
+```
+
+## Solution
+
+Remove the `ProvideAutoLoad` attribute. Visual Studio can consume the package's declarative registrations without
+loading the package.
+
+```csharp
+using Microsoft.VisualStudio.Shell;
+
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+class MyPackage : AsyncPackage
+{
+}
+```
+
+If the package needs to run initialization code, override `Initialize` or `InitializeAsync` as appropriate instead
+of removing `ProvideAutoLoad`.

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,7 @@ ID | Title | Category
 [VSSDK007](VSSDK007.md) | Avoid ThreadHelper for fire and forget tasks | Reliability
 [VSSDK008](VSSDK008.md) | Avoid UI thread in MEF Part construction | Reliability
 [VSSDK009](VSSDK009.md) | Use approved VsTaskRunContext values with VsTaskLibraryHelper | Reliability
+[VSSDK010](VSSDK010.md) | Remove unnecessary ProvideAutoLoad attribute | Performance
 
 This analyzer package also depends on the [Microsoft.VisualStudio.Threading.Analyzers][2] package, which adds [many more analyzers][3].
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ VSSDK006 | Reliability | Warning | VSSDK006CheckServicesExistAnalyzer
 VSSDK007 | Reliability | Warning | VSSDK007ThreadHelperJTFRunAsync
 VSSDK008 | Reliability | Warning | VSSDK008ThreadAffinitizedMEFConstruction
 VSSDK009 | Reliability | Error | VSSDK009UseUIThreadVsTaskRunContextAnalyzer
+VSSDK010 | Performance | Warning | VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.VisualStudio.SDK.Analyzers;
+
+/// <summary>
+/// Reports <see cref="Types.ProvideAutoLoadAttribute"/> usages on packages that do not perform initialization.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+    /// </summary>
+    public const string Id = "VSSDK010";
+
+    /// <summary>
+    /// A reusable descriptor for diagnostics produced by this analyzer.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Descriptor = new(
+        id: Id,
+        title: "Remove unnecessary ProvideAutoLoad attribute",
+        messageFormat: "Remove this ProvideAutoLoad attribute because the package does not override {0}",
+        description: "A package that only provides registration attributes does not need to be automatically loaded.",
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDiagnostics = ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDiagnostics;
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+        context.RegisterCompilationStartAction(start =>
+        {
+            INamedTypeSymbol? packageType = start.Compilation.GetTypeByMetadataName(Types.Package.FullName);
+            INamedTypeSymbol? asyncPackageType = start.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName);
+            INamedTypeSymbol? provideAutoLoadAttributeType = start.Compilation.GetTypeByMetadataName(Types.ProvideAutoLoadAttribute.FullName);
+            IMethodSymbol? initializeMethod = packageType?.GetMembers(Types.Package.Initialize)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(method => method.Parameters.Length == 0);
+            IMethodSymbol? initializeAsyncMethod = asyncPackageType?.GetMembers(Types.AsyncPackage.InitializeAsync)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(method => method.Parameters.Length == 2);
+
+            if (packageType is not null &&
+                asyncPackageType is not null &&
+                provideAutoLoadAttributeType is not null &&
+                initializeMethod is not null &&
+                initializeAsyncMethod is not null)
+            {
+                start.RegisterSymbolAction(
+                    Utils.DebuggableWrapper(symbolContext => AnalyzeNamedType(
+                        symbolContext,
+                        packageType,
+                        asyncPackageType,
+                        provideAutoLoadAttributeType,
+                        initializeMethod,
+                        initializeAsyncMethod)),
+                    SymbolKind.NamedType);
+            }
+        });
+    }
+
+    private static void AnalyzeNamedType(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol packageType,
+        INamedTypeSymbol asyncPackageType,
+        INamedTypeSymbol provideAutoLoadAttributeType,
+        IMethodSymbol initializeMethod,
+        IMethodSymbol initializeAsyncMethod)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+        if (type.TypeKind != TypeKind.Class || type.IsAbstract || !Utils.IsDerivedFrom(type, packageType))
+        {
+            return;
+        }
+
+        ImmutableArray<AttributeData> provideAutoLoadAttributes = type.GetAttributes()
+            .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, provideAutoLoadAttributeType))
+            .ToImmutableArray();
+        if (provideAutoLoadAttributes.IsEmpty)
+        {
+            return;
+        }
+
+        IMethodSymbol methodToOverride;
+        if (Utils.IsEqualToOrDerivedFrom(type, asyncPackageType))
+        {
+            methodToOverride = initializeAsyncMethod;
+        }
+        else
+        {
+            methodToOverride = initializeMethod;
+        }
+
+        if (OverridesMethod(type, methodToOverride))
+        {
+            return;
+        }
+
+        foreach (AttributeData attribute in provideAutoLoadAttributes)
+        {
+            Location? location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
+            if (location is not null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, methodToOverride.Name));
+            }
+        }
+    }
+
+    private static bool OverridesMethod(INamedTypeSymbol type, IMethodSymbol methodToOverride)
+    {
+        for (INamedTypeSymbol? currentType = type; currentType is not null; currentType = currentType.BaseType)
+        {
+            foreach (IMethodSymbol candidate in currentType.GetMembers(methodToOverride.Name).OfType<IMethodSymbol>())
+            {
+                for (IMethodSymbol? overriddenMethod = candidate.OverriddenMethod; overriddenMethod is not null; overriddenMethod = overriddenMethod.OverriddenMethod)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(overriddenMethod, methodToOverride))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Xunit;
+using Verify = CSharpCodeFixVerifier<
+    Microsoft.VisualStudio.SDK.Analyzers.VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests
+{
+    [Fact]
+    public async Task PackageWithoutInitializeOverrideProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[{|#0:ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")|}]
+class Test : Package
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("Initialize"));
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithoutInitializeAsyncOverrideProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[{|#0:ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)|}]
+class Test : AsyncPackage
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("InitializeAsync"));
+    }
+
+    [Fact]
+    public async Task MultipleProvideAutoLoadAttributesProduceMultipleDiagnosticsAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[{|#0:ProvideAutoLoad(""{A184B08F-C81C-45F6-A57F-5ABD9991F28F}"")|}]
+[{|#1:ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")|}]
+class Test : Package
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(
+            test,
+            Verify.Diagnostic().WithLocation(0).WithArguments("Initialize"),
+            Verify.Diagnostic().WithLocation(1).WithArguments("Initialize"));
+    }
+
+    [Fact]
+    public async Task PackageWithInitializeOverrideProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
+class Test : Package
+{
+    protected override void Initialize()
+    {
+        base.Initialize();
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithInitializeAsyncOverrideProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
+class Test : AsyncPackage
+{
+    protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        return base.InitializeAsync(cancellationToken, progress);
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task InheritedInitializeAsyncOverrideProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+
+abstract class BasePackage : AsyncPackage
+{
+    protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        return base.InitializeAsync(cancellationToken, progress);
+    }
+}
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
+class Test : BasePackage
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ProvideAutoLoadOnAbstractBasePackageProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
+abstract class BasePackage : Package
+{
+}
+
+class Test : BasePackage
+{
+    protected override void Initialize()
+    {
+        base.Initialize();
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task UnrelatedInitializeMethodStillProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[{|#0:ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")|}]
+class Test : Package
+{
+    private void Initialize(int value)
+    {
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("Initialize"));
+    }
+
+    [Fact]
+    public async Task ProvideAutoLoadOnNonPackageProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")]
+class Test
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task PackageWithoutProvideAutoLoadProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using Microsoft.VisualStudio.Shell;
+
+class Test : Package
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
Packages that only provide declarative registrations do not need to be automatically loaded, and doing so adds unnecessary performance cost.

This adds VSSDK010, which reports each `ProvideAutoLoad` attribute on a concrete `Package` or `AsyncPackage` that does not override the applicable initialization method. Override detection follows intermediate base classes, while abstract attribute carriers are excluded because derived packages may depend on their inherited autoload registration. The change includes positive, negative, inheritance, and multiple-attribute coverage, plus rule documentation and release metadata.

Fixes #54