### PR TITLE
Add VSSDK011 for async package service registration

### DIFF
--- a/doc/VSSDK011.md
+++ b/doc/VSSDK011.md
@@ -7,8 +7,9 @@ This analyzer flags:
 
 - `ProvideService` attributes on an `AsyncPackage`-derived class when `IsAsyncQueryable` is omitted
   or set to `false`.
-- Services registered on an `AsyncPackage` through the synchronous `IServiceContainer.AddService`
-  API instead of an asynchronous, `Task`-returning service factory.
+- Services registered on an `AsyncPackage` through the `IServiceContainer.AddService` overload that
+  accepts a synchronous `ServiceCreatorCallback`. The overload that accepts a service instance
+  directly is allowed.
 
 ## Example of a pattern that is flagged by this analyzer
 
@@ -31,7 +32,8 @@ class MyPackage : AsyncPackage
 ## Solution
 
 Set `IsAsyncQueryable` to `true` and register the service with an asynchronous, `Task`-returning service
-factory.
+factory. If the service instance already exists, it may instead be registered directly with the
+`IServiceContainer.AddService(Type, object)` overload.
 
 ```csharp
 [ProvideService(typeof(SMyService), IsAsyncQueryable = true)]

--- a/doc/VSSDK011.md
+++ b/doc/VSSDK011.md
@@ -1,7 +1,7 @@
 # VSSDK011 Provide services asynchronously from AsyncPackage
 
 Services proffered by an `AsyncPackage` should be asynchronously queryable so that requesting a service
-through `IAsyncServiceProvider.QueryServiceAsync` does not synchronously load the package.
+through `IAsyncServiceProvider.GetServiceAsync` does not synchronously load the package.
 
 This analyzer flags:
 

--- a/doc/VSSDK011.md
+++ b/doc/VSSDK011.md
@@ -1,0 +1,56 @@
+# VSSDK011 Provide services asynchronously from AsyncPackage
+
+Services proffered by an `AsyncPackage` should be asynchronously queryable so that requesting a service
+through `IAsyncServiceProvider.QueryServiceAsync` does not synchronously load the package.
+
+This analyzer flags:
+
+- `ProvideService` attributes on an `AsyncPackage`-derived class when `IsAsyncQueryable` is omitted
+  or set to `false`.
+- Services registered on an `AsyncPackage` through the synchronous `IServiceContainer.AddService`
+  API instead of an asynchronous, `Task`-returning service factory.
+
+## Example of a pattern that is flagged by this analyzer
+
+```csharp
+[ProvideService(typeof(SMyService))]
+class MyPackage : AsyncPackage
+{
+    private void RegisterService()
+    {
+        ((IServiceContainer)this).AddService(typeof(SMyService), this.CreateMyService);
+    }
+
+    private object CreateMyService(IServiceContainer container, Type serviceType)
+    {
+        return new MyService();
+    }
+}
+```
+
+## Solution
+
+Set `IsAsyncQueryable` to `true` and register the service with an asynchronous, `Task`-returning service
+factory.
+
+```csharp
+[ProvideService(typeof(SMyService), IsAsyncQueryable = true)]
+class MyPackage : AsyncPackage
+{
+    protected override async Task InitializeAsync(
+        CancellationToken cancellationToken,
+        IProgress<ServiceProgressData> progress)
+    {
+        await base.InitializeAsync(cancellationToken, progress);
+        this.AddService(typeof(SMyService), this.CreateMyServiceAsync);
+    }
+
+    private Task<object> CreateMyServiceAsync(
+        IAsyncServiceContainer container,
+        CancellationToken cancellationToken,
+        Type serviceType)
+    {
+        return Task.FromResult<object>(new MyService());
+    }
+}
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,7 @@ ID | Title | Category
 [VSSDK007](VSSDK007.md) | Avoid ThreadHelper for fire and forget tasks | Reliability
 [VSSDK008](VSSDK008.md) | Avoid UI thread in MEF Part construction | Reliability
 [VSSDK009](VSSDK009.md) | Use approved VsTaskRunContext values with VsTaskLibraryHelper | Reliability
+[VSSDK011](VSSDK011.md) | Provide services asynchronously from AsyncPackage | Performance
 
 This analyzer package also depends on the [Microsoft.VisualStudio.Threading.Analyzers][2] package, which adds [many more analyzers][3].
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ VSSDK006 | Reliability | Warning | VSSDK006CheckServicesExistAnalyzer
 VSSDK007 | Reliability | Warning | VSSDK007ThreadHelperJTFRunAsync
 VSSDK008 | Reliability | Warning | VSSDK008ThreadAffinitizedMEFConstruction
 VSSDK009 | Reliability | Error | VSSDK009UseUIThreadVsTaskRunContextAnalyzer
+VSSDK011 | Performance | Warning | VSSDK011ProvideServiceAttributeAnalyzer

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
@@ -58,6 +58,14 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             nameof(System));
 
         /// <summary>
+        /// Gets an array for each element in the namespace System.ComponentModel.Design.
+        /// </summary>
+        internal static readonly ImmutableArray<string> SystemComponentModelDesign = ImmutableArray.Create(
+            nameof(System),
+            nameof(global::System.ComponentModel),
+            "Design");
+
+        /// <summary>
         /// Gets an array for each element in the namespace System.Threading.
         /// </summary>
         internal static readonly ImmutableArray<string> SystemThreading = ImmutableArray.Create(

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -105,6 +105,53 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         }
 
         /// <summary>
+        /// Describes the System.ComponentModel.Design.IServiceContainer type.
+        /// </summary>
+        internal static class IServiceContainer
+        {
+            /// <summary>
+            /// Gets the simple name of the System.ComponentModel.Design.IServiceContainer type.
+            /// </summary>
+            internal const string TypeName = "IServiceContainer";
+
+            /// <summary>
+            /// Gets the name of the System.ComponentModel.Design.IServiceContainer.AddService method.
+            /// </summary>
+            internal const string AddService = "AddService";
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemComponentModelDesign;
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
+        /// Describes the System.ComponentModel.Design.ServiceCreatorCallback type.
+        /// </summary>
+        internal static class ServiceCreatorCallback
+        {
+            /// <summary>
+            /// Gets the simple name of the System.ComponentModel.Design.ServiceCreatorCallback type.
+            /// </summary>
+            internal const string TypeName = "ServiceCreatorCallback";
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.SystemComponentModelDesign;
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
         /// Describes the "Shell.ServiceProvider" type.
         /// </summary>
         internal static class ServiceProvider
@@ -617,6 +664,32 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             /// Gets the <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax"/> for this type.
             /// </summary>
             internal static TypeSyntax TypeSyntax { get; } = Utils.QualifyName(Namespace, SyntaxFactory.IdentifierName(TypeName));
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
+        /// Describes the "Shell.ProvideServiceAttribute" type.
+        /// </summary>
+        internal static class ProvideServiceAttribute
+        {
+            /// <summary>
+            /// Gets the simple name of the "Shell.ProvideServiceAttribute" type.
+            /// </summary>
+            internal const string TypeName = "ProvideServiceAttribute";
+
+            /// <summary>
+            /// Gets the name of the "Shell.ProvideServiceAttribute.IsAsyncQueryable" property.
+            /// </summary>
+            internal const string IsAsyncQueryable = "IsAsyncQueryable";
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudioShell;
 
             /// <summary>
             /// Gets the fully-qualified name of this type as a string.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
@@ -28,7 +28,7 @@ public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
     internal static readonly DiagnosticDescriptor Descriptor = new(
         id: Id,
         title: "Provide services asynchronously from AsyncPackage",
-        messageFormat: "Services provided by an AsyncPackage must be asynchronously queryable and registered with a Task-returning service factory",
+        messageFormat: "Services provided by an AsyncPackage must be asynchronously queryable and must not use a synchronous service factory",
         helpLinkUri: Utils.GetHelpLink(Id),
         category: "Performance",
         defaultSeverity: DiagnosticSeverity.Warning,

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -108,7 +109,7 @@ public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
             invocation.TargetMethod.Parameters.Length < 2 ||
             !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.Parameters[1].Type, serviceCreatorCallbackType) ||
             !Utils.IsEqualToOrDerivedFrom(context.ContainingSymbol.ContainingType, asyncPackageType) ||
-            !IsContainingTypeInstance(invocation.Instance))
+            !IsContainingTypeInstance(invocation.Instance, GetRootOperation(invocation), new HashSet<ISymbol>(SymbolEqualityComparer.Default)))
         {
             return;
         }
@@ -117,13 +118,85 @@ public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, serviceFactoryArgument?.Syntax.GetLocation() ?? invocation.Syntax.GetLocation()));
     }
 
-    private static bool IsContainingTypeInstance(IOperation? operation)
+    private static IOperation GetRootOperation(IOperation operation)
+    {
+        while (operation.Parent is not null)
+        {
+            operation = operation.Parent;
+        }
+
+        return operation;
+    }
+
+    private static bool IsContainingTypeInstance(IOperation? operation, IOperation rootOperation, HashSet<ISymbol> visitedSymbols)
     {
         while (operation is IConversionOperation conversion)
         {
             operation = conversion.Operand;
         }
 
-        return operation is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance };
+        return operation switch
+        {
+            IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance } => true,
+            ILocalReferenceOperation localReference => IsAliasForContainingTypeInstance(localReference.Local, rootOperation, visitedSymbols),
+            IFieldReferenceOperation fieldReference => IsAliasForContainingTypeInstance(fieldReference.Field, rootOperation, visitedSymbols),
+            _ => false,
+        };
+    }
+
+    private static bool IsAliasForContainingTypeInstance(ISymbol symbol, IOperation rootOperation, HashSet<ISymbol> visitedSymbols)
+    {
+        if (!visitedSymbols.Add(symbol))
+        {
+            return false;
+        }
+
+        try
+        {
+            bool foundAssignment = false;
+            foreach (IOperation operation in rootOperation.DescendantsAndSelf())
+            {
+                IOperation? value = operation switch
+                {
+                    IVariableDeclaratorOperation declarator when
+                        SymbolEqualityComparer.Default.Equals(declarator.Symbol, symbol) => declarator.Initializer?.Value,
+                    ISimpleAssignmentOperation assignment when
+                        SymbolEqualityComparer.Default.Equals(GetReferencedSymbol(assignment.Target), symbol) => assignment.Value,
+                    _ => null,
+                };
+
+                if (value is null)
+                {
+                    continue;
+                }
+
+                foundAssignment = true;
+                if (!IsContainingTypeInstance(value, rootOperation, visitedSymbols))
+                {
+                    return false;
+                }
+            }
+
+            return foundAssignment;
+        }
+        finally
+        {
+            visitedSymbols.Remove(symbol);
+        }
+    }
+
+    private static ISymbol? GetReferencedSymbol(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation switch
+        {
+            ILocalReferenceOperation localReference => localReference.Local,
+            IFieldReferenceOperation fieldReference => fieldReference.Field,
+            _ => null,
+        };
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
@@ -68,9 +68,21 @@ public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
             INamedTypeSymbol? serviceCreatorCallbackType = context.Compilation.GetTypeByMetadataName(Types.ServiceCreatorCallback.FullName);
             if (serviceContainerType is not null && serviceCreatorCallbackType is not null)
             {
-                context.RegisterOperationAction(
-                    Utils.DebuggableWrapper((OperationAnalysisContext context) => AnalyzeInvocation(context, asyncPackageType, serviceContainerType, serviceCreatorCallbackType)),
-                    OperationKind.Invocation);
+                context.RegisterSymbolStartAction(
+                    context =>
+                    {
+                        var namedType = (INamedTypeSymbol)context.Symbol;
+                        if (!Utils.IsEqualToOrDerivedFrom(namedType.BaseType, asyncPackageType))
+                        {
+                            return;
+                        }
+
+                        var state = new ServiceRegistrationAnalysisState(namedType, serviceContainerType, serviceCreatorCallbackType);
+                        context.RegisterOperationAction(Utils.DebuggableWrapper(state.AnalyzeAssignment), OperationKind.SimpleAssignment);
+                        context.RegisterOperationAction(Utils.DebuggableWrapper(state.AnalyzeInvocation), OperationKind.Invocation);
+                        context.RegisterSymbolEndAction(Utils.DebuggableWrapper(state.AnalyzeSymbolEnd));
+                    },
+                    SymbolKind.NamedType);
             }
         });
     }
@@ -95,27 +107,6 @@ public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
                 .FirstOrDefault(a => a.NameEquals?.Name.Identifier.ValueText == Types.ProvideServiceAttribute.IsAsyncQueryable);
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, isAsyncQueryableArgument?.GetLocation() ?? attributeSyntax.GetLocation()));
         }
-    }
-
-    private static void AnalyzeInvocation(
-        OperationAnalysisContext context,
-        INamedTypeSymbol asyncPackageType,
-        INamedTypeSymbol serviceContainerType,
-        INamedTypeSymbol serviceCreatorCallbackType)
-    {
-        var invocation = (IInvocationOperation)context.Operation;
-        if (invocation.TargetMethod.Name != Types.IServiceContainer.AddService ||
-            !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, serviceContainerType) ||
-            invocation.TargetMethod.Parameters.Length < 2 ||
-            !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.Parameters[1].Type, serviceCreatorCallbackType) ||
-            !Utils.IsEqualToOrDerivedFrom(context.ContainingSymbol.ContainingType, asyncPackageType) ||
-            !IsContainingTypeInstance(invocation.Instance, GetRootOperation(invocation), new HashSet<ISymbol>(SymbolEqualityComparer.Default)))
-        {
-            return;
-        }
-
-        IArgumentOperation? serviceFactoryArgument = invocation.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 1);
-        context.ReportDiagnostic(Diagnostic.Create(Descriptor, serviceFactoryArgument?.Syntax.GetLocation() ?? invocation.Syntax.GetLocation()));
     }
 
     private static IOperation GetRootOperation(IOperation operation)
@@ -198,5 +189,110 @@ public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
             IFieldReferenceOperation fieldReference => fieldReference.Field,
             _ => null,
         };
+    }
+
+    private sealed class ServiceRegistrationAnalysisState
+    {
+        private readonly object syncObject = new();
+        private readonly INamedTypeSymbol packageType;
+        private readonly INamedTypeSymbol serviceContainerType;
+        private readonly INamedTypeSymbol serviceCreatorCallbackType;
+        private readonly Dictionary<IFieldSymbol, FieldAliasState> fieldAliases = new(SymbolEqualityComparer.Default);
+        private readonly List<(IFieldSymbol Field, Location Location)> fieldInvocations = new();
+
+        internal ServiceRegistrationAnalysisState(
+            INamedTypeSymbol packageType,
+            INamedTypeSymbol serviceContainerType,
+            INamedTypeSymbol serviceCreatorCallbackType)
+        {
+            this.packageType = packageType;
+            this.serviceContainerType = serviceContainerType;
+            this.serviceCreatorCallbackType = serviceCreatorCallbackType;
+        }
+
+        internal void AnalyzeAssignment(OperationAnalysisContext context)
+        {
+            var assignment = (ISimpleAssignmentOperation)context.Operation;
+            if (GetReferencedSymbol(assignment.Target) is not IFieldSymbol field ||
+                !SymbolEqualityComparer.Default.Equals(field.ContainingType, this.packageType))
+            {
+                return;
+            }
+
+            bool isPackageAlias = IsContainingTypeInstance(
+                assignment.Value,
+                GetRootOperation(assignment),
+                new HashSet<ISymbol>(SymbolEqualityComparer.Default));
+            lock (this.syncObject)
+            {
+                if (!this.fieldAliases.TryGetValue(field, out FieldAliasState? aliasState))
+                {
+                    aliasState = new FieldAliasState();
+                    this.fieldAliases.Add(field, aliasState);
+                }
+
+                aliasState.HasPackageAssignment |= isPackageAlias;
+                aliasState.HasOtherAssignment |= !isPackageAlias;
+            }
+        }
+
+        internal void AnalyzeInvocation(OperationAnalysisContext context)
+        {
+            var invocation = (IInvocationOperation)context.Operation;
+            if (invocation.TargetMethod.Name != Types.IServiceContainer.AddService ||
+                !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, this.serviceContainerType) ||
+                invocation.TargetMethod.Parameters.Length < 2 ||
+                !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.Parameters[1].Type, this.serviceCreatorCallbackType))
+            {
+                return;
+            }
+
+            IArgumentOperation? serviceFactoryArgument = invocation.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 1);
+            Location location = serviceFactoryArgument?.Syntax.GetLocation() ?? invocation.Syntax.GetLocation();
+            IOperation? instance = invocation.Instance;
+            while (instance is IConversionOperation conversion)
+            {
+                instance = conversion.Operand;
+            }
+
+            if (instance is IFieldReferenceOperation fieldReference &&
+                SymbolEqualityComparer.Default.Equals(fieldReference.Field.ContainingType, this.packageType))
+            {
+                lock (this.syncObject)
+                {
+                    this.fieldInvocations.Add((fieldReference.Field, location));
+                }
+
+                return;
+            }
+
+            if (IsContainingTypeInstance(instance, GetRootOperation(invocation), new HashSet<ISymbol>(SymbolEqualityComparer.Default)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+            }
+        }
+
+        internal void AnalyzeSymbolEnd(SymbolAnalysisContext context)
+        {
+            lock (this.syncObject)
+            {
+                foreach ((IFieldSymbol field, Location location) in this.fieldInvocations)
+                {
+                    if (this.fieldAliases.TryGetValue(field, out FieldAliasState? aliasState) &&
+                        aliasState.HasPackageAssignment &&
+                        !aliasState.HasOtherAssignment)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                    }
+                }
+            }
+        }
+
+        private sealed class FieldAliasState
+        {
+            internal bool HasPackageAssignment { get; set; }
+
+            internal bool HasOtherAssignment { get; set; }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK011ProvideServiceAttributeAnalyzer.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.VisualStudio.SDK.Analyzers;
+
+/// <summary>
+/// Discovers services provided by an <c>AsyncPackage</c> without asynchronous query support.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class VSSDK011ProvideServiceAttributeAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+    /// </summary>
+    public const string Id = "VSSDK011";
+
+    /// <summary>
+    /// A reusable descriptor for diagnostics produced by this analyzer.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Descriptor = new(
+        id: Id,
+        title: "Provide services asynchronously from AsyncPackage",
+        messageFormat: "Services provided by an AsyncPackage must be asynchronously queryable and registered with a Task-returning service factory",
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+        context.RegisterCompilationStartAction(context =>
+        {
+            INamedTypeSymbol? asyncPackageType = context.Compilation.GetTypeByMetadataName(Types.AsyncPackage.FullName);
+            if (asyncPackageType is null)
+            {
+                return;
+            }
+
+            INamedTypeSymbol? provideServiceAttributeType = context.Compilation.GetTypeByMetadataName(Types.ProvideServiceAttribute.FullName);
+            if (provideServiceAttributeType is not null)
+            {
+                context.RegisterSymbolAction(
+                    Utils.DebuggableWrapper((SymbolAnalysisContext context) => AnalyzeNamedType(context, asyncPackageType, provideServiceAttributeType)),
+                    SymbolKind.NamedType);
+            }
+
+            INamedTypeSymbol? serviceContainerType = context.Compilation.GetTypeByMetadataName(Types.IServiceContainer.FullName);
+            INamedTypeSymbol? serviceCreatorCallbackType = context.Compilation.GetTypeByMetadataName(Types.ServiceCreatorCallback.FullName);
+            if (serviceContainerType is not null && serviceCreatorCallbackType is not null)
+            {
+                context.RegisterOperationAction(
+                    Utils.DebuggableWrapper((OperationAnalysisContext context) => AnalyzeInvocation(context, asyncPackageType, serviceContainerType, serviceCreatorCallbackType)),
+                    OperationKind.Invocation);
+            }
+        });
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context, INamedTypeSymbol asyncPackageType, INamedTypeSymbol provideServiceAttributeType)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+        if (!Utils.IsEqualToOrDerivedFrom(namedType.BaseType, asyncPackageType))
+        {
+            return;
+        }
+
+        foreach (AttributeData attribute in namedType.GetAttributes().Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, provideServiceAttributeType)))
+        {
+            bool isAsyncQueryable = attribute.NamedArguments.FirstOrDefault(a => a.Key == Types.ProvideServiceAttribute.IsAsyncQueryable).Value.Value as bool? ?? false;
+            if (isAsyncQueryable || attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is not AttributeSyntax attributeSyntax)
+            {
+                continue;
+            }
+
+            AttributeArgumentSyntax? isAsyncQueryableArgument = attributeSyntax.ArgumentList?.Arguments
+                .FirstOrDefault(a => a.NameEquals?.Name.Identifier.ValueText == Types.ProvideServiceAttribute.IsAsyncQueryable);
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, isAsyncQueryableArgument?.GetLocation() ?? attributeSyntax.GetLocation()));
+        }
+    }
+
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        INamedTypeSymbol asyncPackageType,
+        INamedTypeSymbol serviceContainerType,
+        INamedTypeSymbol serviceCreatorCallbackType)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        if (invocation.TargetMethod.Name != Types.IServiceContainer.AddService ||
+            !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, serviceContainerType) ||
+            invocation.TargetMethod.Parameters.Length < 2 ||
+            !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.Parameters[1].Type, serviceCreatorCallbackType) ||
+            !Utils.IsEqualToOrDerivedFrom(context.ContainingSymbol.ContainingType, asyncPackageType) ||
+            !IsContainingTypeInstance(invocation.Instance))
+        {
+            return;
+        }
+
+        IArgumentOperation? serviceFactoryArgument = invocation.Arguments.FirstOrDefault(a => a.Parameter?.Ordinal == 1);
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, serviceFactoryArgument?.Syntax.GetLocation() ?? invocation.Syntax.GetLocation()));
+    }
+
+    private static bool IsContainingTypeInstance(IOperation? operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance };
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK011ProvideServiceAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK011ProvideServiceAttributeAnalyzerTests.cs
@@ -229,9 +229,13 @@ public class VSSDK011ProvideServiceAttributeAnalyzerTests
             {
                 private IServiceContainer serviceContainer;
 
-                private void RegisterService()
+                public TestPackage()
                 {
                     this.serviceContainer = this;
+                }
+
+                private void RegisterService()
+                {
                     this.serviceContainer.AddService(typeof(TestService), [|this.CreateService|]);
                 }
 
@@ -262,6 +266,42 @@ public class VSSDK011ProvideServiceAttributeAnalyzerTests
                 private void RegisterService(IServiceContainer container)
                 {
                     container.AddService(typeof(TestService), this.CreateService);
+                }
+
+                private object CreateService(IServiceContainer container, Type serviceType)
+                {
+                    return new TestService();
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageAddingServiceThroughUnrelatedContainerFieldProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            class TestPackage : AsyncPackage
+            {
+                private IServiceContainer serviceContainer;
+
+                public TestPackage(IServiceContainer serviceContainer)
+                {
+                    this.serviceContainer = serviceContainer;
+                }
+
+                private void RegisterService()
+                {
+                    this.serviceContainer.AddService(typeof(TestService), this.CreateService);
                 }
 
                 private object CreateService(IServiceContainer container, Type serviceType)

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK011ProvideServiceAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK011ProvideServiceAttributeAnalyzerTests.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = CSharpCodeFixVerifier<
+    Microsoft.VisualStudio.SDK.Analyzers.VSSDK011ProvideServiceAttributeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSSDK011ProvideServiceAttributeAnalyzerTests
+{
+    [Fact]
+    public async Task AsyncPackageWithoutProvideServiceProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio.Shell;
+
+            class TestPackage : AsyncPackage
+            {
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task PackageWithSynchronousServiceProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            [ProvideService(typeof(TestService))]
+            class TestPackage : Package
+            {
+                private void RegisterService()
+                {
+                    ((IServiceContainer)this).AddService(typeof(TestService), this.CreateService);
+                }
+
+                private object CreateService(IServiceContainer container, Type serviceType)
+                {
+                    return new TestService();
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithAsyncServiceProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            [ProvideService(typeof(TestService), IsAsyncQueryable = true)]
+            class TestPackage : AsyncPackage
+            {
+                protected override async Task InitializeAsync(
+                    CancellationToken cancellationToken,
+                    IProgress<ServiceProgressData> progress)
+                {
+                    await base.InitializeAsync(cancellationToken, progress);
+                    this.AddService(typeof(TestService), this.CreateServiceAsync);
+                }
+
+                private Task<object> CreateServiceAsync(
+                    IAsyncServiceContainer container,
+                    CancellationToken cancellationToken,
+                    Type serviceType)
+                {
+                    return Task.FromResult<object>(new TestService());
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithDefaultServiceProducesDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            [[|ProvideService(typeof(TestService))|]]
+            class TestPackage : AsyncPackage
+            {
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithExplicitSynchronousServiceProducesDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            [ProvideService(typeof(TestService), [|IsAsyncQueryable = false|])]
+            class TestPackage : AsyncPackage
+            {
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithSynchronousServiceFactoryProducesDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            [ProvideService(typeof(TestService), IsAsyncQueryable = true)]
+            class TestPackage : AsyncPackage
+            {
+                private void RegisterService()
+                {
+                    ((IServiceContainer)this).AddService(typeof(TestService), [|this.CreateService|]);
+                }
+
+                private object CreateService(IServiceContainer container, Type serviceType)
+                {
+                    return new TestService();
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithServiceInstanceProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            [ProvideService(typeof(TestService), IsAsyncQueryable = true)]
+            class TestPackage : AsyncPackage
+            {
+                private void RegisterService()
+                {
+                    ((IServiceContainer)this).AddService(typeof(TestService), new TestService());
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageAddingServiceToAnotherContainerProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            class TestPackage : AsyncPackage
+            {
+                private void RegisterService(IServiceContainer container)
+                {
+                    container.AddService(typeof(TestService), this.CreateService);
+                }
+
+                private object CreateService(IServiceContainer container, Type serviceType)
+                {
+                    return new TestService();
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task DerivedAsyncPackageWithMultipleServicesProducesDiagnosticsForSynchronousServicesAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio.Shell;
+            using ServiceAttribute = Microsoft.VisualStudio.Shell.ProvideServiceAttribute;
+
+            class FirstService
+            {
+            }
+
+            class SecondService
+            {
+            }
+
+            class ThirdService
+            {
+            }
+
+            abstract class IntermediatePackage : AsyncPackage
+            {
+            }
+
+            [[|ServiceAttribute(typeof(FirstService))|]]
+            [ServiceAttribute(typeof(SecondService), IsAsyncQueryable = true)]
+            [ServiceAttribute(typeof(ThirdService), [|IsAsyncQueryable = false|])]
+            class TestPackage : IntermediatePackage
+            {
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task CompilationWithoutVisualStudioSdkProducesNoDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            class Test
+            {
+            }
+            """;
+
+        await new Verify.Test(includeVisualStudioSdk: false)
+        {
+            TestCode = Test,
+        }.RunAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK011ProvideServiceAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK011ProvideServiceAttributeAnalyzerTests.cs
@@ -184,6 +184,68 @@ public class VSSDK011ProvideServiceAttributeAnalyzerTests
     }
 
     [Fact]
+    public async Task AsyncPackageWithSynchronousServiceFactoryThroughLocalAliasProducesDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            class TestPackage : AsyncPackage
+            {
+                private void RegisterService()
+                {
+                    IServiceContainer container = this;
+                    container.AddService(typeof(TestService), [|this.CreateService|]);
+                }
+
+                private object CreateService(IServiceContainer container, Type serviceType)
+                {
+                    return new TestService();
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
+    public async Task AsyncPackageWithSynchronousServiceFactoryThroughFieldAliasProducesDiagnosticAsync()
+    {
+        const string Test = /* lang=c#-test */ """
+            using System;
+            using System.ComponentModel.Design;
+            using Microsoft.VisualStudio.Shell;
+
+            class TestService
+            {
+            }
+
+            class TestPackage : AsyncPackage
+            {
+                private IServiceContainer serviceContainer;
+
+                private void RegisterService()
+                {
+                    this.serviceContainer = this;
+                    this.serviceContainer.AddService(typeof(TestService), [|this.CreateService|]);
+                }
+
+                private object CreateService(IServiceContainer container, Type serviceType)
+                {
+                    return new TestService();
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(Test);
+    }
+
+    [Fact]
     public async Task AsyncPackageAddingServiceToAnotherContainerProducesNoDiagnosticAsync()
     {
         const string Test = /* lang=c#-test */ """


### PR DESCRIPTION
Async packages can still be loaded synchronously when their proffered services are not marked as asynchronously queryable or are registered through a synchronous service factory.

This adds VSSDK011 to:
- require `ProvideServiceAttribute.IsAsyncQueryable = true` on services provided by `AsyncPackage` classes
- report synchronous `ServiceCreatorCallback` registrations made through `IServiceContainer.AddService`
- allow direct service-instance registrations and async `Task<object>` factories

The analyzer handles indirect `AsyncPackage` subclasses, reports the relevant attribute or factory argument, and includes focused coverage and diagnostic documentation.

Fixes #67