### PR TITLE
Add VSSDK012 for outdated VisualStudioServices catalogs

### DIFF
--- a/doc/VSSDK012.md
+++ b/doc/VSSDK012.md
@@ -1,0 +1,21 @@
+# VSSDK012 Use the latest `VisualStudioServices` version
+
+`Microsoft.VisualStudio.VisualStudioServices` exposes versioned service catalogs. Newer catalogs include the services from earlier versions and may provide additional functionality or performance improvements.
+
+This analyzer reports a reference to an older catalog when the referenced Visual Studio SDK exposes a higher-numbered version.
+
+## Example of a pattern that is flagged by this analyzer
+
+```csharp
+var service = VisualStudioServices.VS2019_7.DiagnosticManagerService;
+```
+
+## Solution
+
+Use the latest version available from the referenced Visual Studio SDK.
+
+```csharp
+var service = VisualStudioServices.VS2022_14.DiagnosticManagerService;
+```
+
+Because changing a service version may change behavior, this diagnostic has `Info` severity and does not offer an automatic code fix.

--- a/doc/index.md
+++ b/doc/index.md
@@ -14,6 +14,7 @@ ID | Title | Category
 [VSSDK007](VSSDK007.md) | Avoid ThreadHelper for fire and forget tasks | Reliability
 [VSSDK008](VSSDK008.md) | Avoid UI thread in MEF Part construction | Reliability
 [VSSDK009](VSSDK009.md) | Use approved VsTaskRunContext values with VsTaskLibraryHelper | Reliability
+[VSSDK012](VSSDK012.md) | Use the latest VisualStudioServices version | Performance
 
 This analyzer package also depends on the [Microsoft.VisualStudio.Threading.Analyzers][2] package, which adds [many more analyzers][3].
 

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ VSSDK006 | Reliability | Warning | VSSDK006CheckServicesExistAnalyzer
 VSSDK007 | Reliability | Warning | VSSDK007ThreadHelperJTFRunAsync
 VSSDK008 | Reliability | Warning | VSSDK008ThreadAffinitizedMEFConstruction
 VSSDK009 | Reliability | Error | VSSDK009UseUIThreadVsTaskRunContextAnalyzer
+VSSDK012 | Performance | Info | VSSDK012UseLatestVisualStudioServicesVersionAnalyzer

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Namespaces.cs
@@ -18,6 +18,13 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             nameof(Microsoft));
 
         /// <summary>
+        /// Gets an array for each element in the namespace Microsoft.VisualStudio.
+        /// </summary>
+        internal static readonly ImmutableArray<string> MicrosoftVisualStudio = ImmutableArray.Create(
+            nameof(Microsoft),
+            nameof(VisualStudio));
+
+        /// <summary>
         /// Gets an array for each element in the namespace Microsoft.VisualStudio.Shell.
         /// </summary>
         internal static readonly ImmutableArray<string> MicrosoftVisualStudioShell = ImmutableArray.Create(

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -43,6 +43,27 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
         }
 
         /// <summary>
+        /// Describes the "Microsoft.VisualStudio.VisualStudioServices" type.
+        /// </summary>
+        internal static class VisualStudioServices
+        {
+            /// <summary>
+            /// Gets the simple name of the "Microsoft.VisualStudio.VisualStudioServices" type.
+            /// </summary>
+            internal const string TypeName = nameof(VisualStudioServices);
+
+            /// <summary>
+            /// Gets an array of the nesting namespaces for this type.
+            /// </summary>
+            internal static readonly IReadOnlyList<string> Namespace = Namespaces.MicrosoftVisualStudio;
+
+            /// <summary>
+            /// Gets the fully-qualified name of this type as a string.
+            /// </summary>
+            internal static string FullName { get; } = string.Join(".", Namespace) + "." + TypeName;
+        }
+
+        /// <summary>
         /// Describes the Microsoft.VisualStudio.OLE.Interop.IServiceProvider type.
         /// </summary>
         internal static class IOleServiceProvider

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK012UseLatestVisualStudioServicesVersionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK012UseLatestVisualStudioServicesVersionAnalyzer.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.VisualStudio.SDK.Analyzers;
+
+/// <summary>
+/// Reports references to an older version exposed by <see cref="Types.VisualStudioServices"/>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class VSSDK012UseLatestVisualStudioServicesVersionAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The value to use for <see cref="DiagnosticDescriptor.Id"/> in generated diagnostics.
+    /// </summary>
+    public const string Id = "VSSDK012";
+
+    /// <summary>
+    /// A reusable descriptor for diagnostics produced by this analyzer.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Descriptor = new(
+        id: Id,
+        title: "Use the latest VisualStudioServices version",
+        messageFormat: "Use VisualStudioServices.{1} instead of VisualStudioServices.{0}",
+        description: "Use the latest VisualStudioServices version available in the referenced Visual Studio SDK to benefit from the latest service functionality and performance improvements.",
+        helpLinkUri: Utils.GetHelpLink(Id),
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> ReusableSupportedDiagnostics = ImmutableArray.Create(Descriptor);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ReusableSupportedDiagnostics;
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+        context.RegisterCompilationStartAction(start =>
+        {
+            INamedTypeSymbol? visualStudioServices = start.Compilation.GetTypeByMetadataName(Types.VisualStudioServices.FullName);
+            if (visualStudioServices is null ||
+                !TryGetLatestVersionProperty(visualStudioServices, out IPropertySymbol? latestProperty, out Version? latestVersion))
+            {
+                return;
+            }
+
+            start.RegisterOperationAction(
+                Utils.DebuggableWrapper(context => AnalyzePropertyReference(context, visualStudioServices, latestProperty, latestVersion)),
+                OperationKind.PropertyReference);
+        });
+    }
+
+    private static void AnalyzePropertyReference(
+        OperationAnalysisContext context,
+        INamedTypeSymbol visualStudioServices,
+        IPropertySymbol latestProperty,
+        Version latestVersion)
+    {
+        var propertyReference = (IPropertyReferenceOperation)context.Operation;
+        for (IOperation? ancestor = propertyReference.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is INameOfOperation)
+            {
+                return;
+            }
+        }
+
+        IPropertySymbol property = propertyReference.Property;
+        if (!SymbolEqualityComparer.Default.Equals(property.ContainingType, visualStudioServices) ||
+            SymbolEqualityComparer.Default.Equals(property, latestProperty) ||
+            !TryGetVersion(property.Name, out Version? referencedVersion) ||
+            referencedVersion.CompareTo(latestVersion) >= 0)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, propertyReference.Syntax.GetLocation(), property.Name, latestProperty.Name));
+    }
+
+    private static bool TryGetLatestVersionProperty(
+        INamedTypeSymbol visualStudioServices,
+        [NotNullWhen(true)] out IPropertySymbol? latestProperty,
+        [NotNullWhen(true)] out Version? latestVersion)
+    {
+        latestProperty = null;
+        latestVersion = null;
+
+        foreach (IPropertySymbol property in visualStudioServices.GetMembers().OfType<IPropertySymbol>())
+        {
+            if (TryGetVersion(property.Name, out Version? version) &&
+                (latestVersion is null || version.CompareTo(latestVersion) > 0))
+            {
+                latestProperty = property;
+                latestVersion = version;
+            }
+        }
+
+        return latestProperty is not null;
+    }
+
+    private static bool TryGetVersion(string memberName, [NotNullWhen(true)] out Version? version)
+    {
+        const string prefix = "VS";
+        version = null;
+        if (!memberName.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int separatorIndex = memberName.IndexOf('_', prefix.Length);
+        string majorText = separatorIndex < 0
+            ? memberName.Substring(prefix.Length)
+            : memberName.Substring(prefix.Length, separatorIndex - prefix.Length);
+        string minorText = separatorIndex < 0 ? "0" : memberName.Substring(separatorIndex + 1);
+        if (majorText.Length != 4 ||
+            minorText.Length == 0 ||
+            minorText.IndexOf('_') >= 0 ||
+            !int.TryParse(majorText, NumberStyles.None, CultureInfo.InvariantCulture, out int major) ||
+            !int.TryParse(minorText, NumberStyles.None, CultureInfo.InvariantCulture, out int minor))
+        {
+            return false;
+        }
+
+        version = new Version(major, minor);
+        return true;
+    }
+}

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK012UseLatestVisualStudioServicesVersionAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK012UseLatestVisualStudioServicesVersionAnalyzer.cs
@@ -73,14 +73,6 @@ public class VSSDK012UseLatestVisualStudioServicesVersionAnalyzer : DiagnosticAn
         Version latestVersion)
     {
         var propertyReference = (IPropertyReferenceOperation)context.Operation;
-        for (IOperation? ancestor = propertyReference.Parent; ancestor is not null; ancestor = ancestor.Parent)
-        {
-            if (ancestor is INameOfOperation)
-            {
-                return;
-            }
-        }
-
         IPropertySymbol property = propertyReference.Property;
         if (!SymbolEqualityComparer.Default.Equals(property.ContainingType, visualStudioServices) ||
             SymbolEqualityComparer.Default.Equals(property, latestProperty) ||
@@ -88,6 +80,14 @@ public class VSSDK012UseLatestVisualStudioServicesVersionAnalyzer : DiagnosticAn
             referencedVersion.CompareTo(latestVersion) >= 0)
         {
             return;
+        }
+
+        for (IOperation? ancestor = propertyReference.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is INameOfOperation)
+            {
+                return;
+            }
         }
 
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, propertyReference.Syntax.GetLocation(), property.Name, latestProperty.Name));

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK012UseLatestVisualStudioServicesVersionAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK012UseLatestVisualStudioServicesVersionAnalyzerTests.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = CSharpCodeFixVerifier<
+    Microsoft.VisualStudio.SDK.Analyzers.VSSDK012UseLatestVisualStudioServicesVersionAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class VSSDK012UseLatestVisualStudioServicesVersionAnalyzerTests
+{
+    [Fact]
+    public async Task OlderVersionProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = {|#0:VisualStudioServices.VS2019_9|}.DiagnosticManagerService;
+                }
+            }
+
+            namespace Microsoft.VisualStudio
+            {
+                public static class VisualStudioServices
+                {
+                    public static VS2019_9Services VS2019_9 => new VS2019_9Services();
+                    public static VS2019_10Services VS2019_10 => new VS2019_10Services();
+                }
+
+                public class VS2019_9Services
+                {
+                    public object DiagnosticManagerService => new object();
+                }
+
+                public class VS2019_10Services : VS2019_9Services
+                {
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("VS2019_9", "VS2019_10"));
+    }
+
+    [Fact]
+    public async Task VersionFromOlderVisualStudioReleaseProducesDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = {|#0:VisualStudioServices.VS2019_11|};
+                }
+            }
+
+            namespace Microsoft.VisualStudio
+            {
+                public static class VisualStudioServices
+                {
+                    public static object VS2019_11 => new object();
+                    public static object VS2022 => new object();
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test, Verify.Diagnostic().WithLocation(0).WithArguments("VS2019_11", "VS2022"));
+    }
+
+    [Fact]
+    public async Task LatestVersionProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = VisualStudioServices.VS2022_10;
+                }
+            }
+
+            namespace Microsoft.VisualStudio
+            {
+                public static class VisualStudioServices
+                {
+                    public static object VS2022_9 => new object();
+                    public static object VS2022_10 => new object();
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task OnlyAvailableVersionProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = VisualStudioServices.VS2019_7;
+                }
+            }
+
+            namespace Microsoft.VisualStudio
+            {
+                public static class VisualStudioServices
+                {
+                    public static object VS2019_7 => new object();
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonVersionedMemberProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio;
+
+            class Test
+            {
+                void M()
+                {
+                    _ = VisualStudioServices.Default;
+                }
+            }
+
+            namespace Microsoft.VisualStudio
+            {
+                public static class VisualStudioServices
+                {
+                    public static object Default => new object();
+                    public static object VS2022 => new object();
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NameOfOlderVersionProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            using Microsoft.VisualStudio;
+
+            class Test
+            {
+                string M()
+                {
+                    return nameof(VisualStudioServices.VS2019_7);
+                }
+            }
+
+            namespace Microsoft.VisualStudio
+            {
+                public static class VisualStudioServices
+                {
+                    public static object VS2019_7 => new object();
+                    public static object VS2022 => new object();
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task UnrelatedTypeProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ """
+            class Test
+            {
+                void M()
+                {
+                    _ = Contoso.VisualStudioServices.VS2019_7;
+                }
+            }
+
+            namespace Contoso
+            {
+                public static class VisualStudioServices
+                {
+                    public static object VS2019_7 => new object();
+                    public static object VS2022 => new object();
+                }
+            }
+            """;
+
+        await VerifyAnalyzerAsync(test);
+    }
+
+    private static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new Verify.Test(includeVisualStudioSdk: false)
+        {
+            TestCode = source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}


### PR DESCRIPTION
Visual Studio extensions can miss functionality or performance improvements when they dereference an older `VisualStudioServices` catalog despite compiling against an SDK that exposes a newer one.

This adds the informational VSSDK012 diagnostic. The analyzer resolves `Microsoft.VisualStudio.VisualStudioServices`, enumerates its versioned properties, compares their numeric major/minor versions, and reports references below the highest available version. It ignores non-versioned members, unrelated types, and `nameof` references. The change also adds focused analyzer coverage, release tracking, and rule documentation. No automatic code fix is provided because changing service versions may affect behavior.

Fixes #129