### PR TITLE
Allow OnAfterPackageLoadedAsync overrides for VSSDK010

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This project is meant to provide a set of Roslyn Analyzers that makes it easy to catch, discover and implement a wide array of best practices when building Visual Studio extensions.
 
-Check out our [exhaustive list of analyzers](https://microsoft.github.io/vssdk-analyzers/analyzers/index.html) defined in this project.
+Check out our [exhaustive list of analyzers](https://microsoft.github.io/VSSDK-Analyzers/analyzers/index.html) defined in this project.
 
 If you have an idea for a rule that would constitute a best practice for extension authors to follow, please open an issue with the description.
 

--- a/doc/VSSDK001.md
+++ b/doc/VSSDK001.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK001.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK001.html).

--- a/doc/VSSDK002.md
+++ b/doc/VSSDK002.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK002.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK002.html).

--- a/doc/VSSDK003.md
+++ b/doc/VSSDK003.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK003.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK003.html).

--- a/doc/VSSDK004.md
+++ b/doc/VSSDK004.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK004.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK004.html).

--- a/doc/VSSDK005.md
+++ b/doc/VSSDK005.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK005.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK005.html).

--- a/doc/VSSDK006.md
+++ b/doc/VSSDK006.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK006.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK006.html).

--- a/doc/VSSDK007.md
+++ b/doc/VSSDK007.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK007.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK007.html).

--- a/doc/VSSDK008.md
+++ b/doc/VSSDK008.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK008.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK008.html).

--- a/doc/VSSDK009.md
+++ b/doc/VSSDK009.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK009.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK009.html).

--- a/doc/VSSDK010.md
+++ b/doc/VSSDK010.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK010.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK010.html).

--- a/doc/VSSDK012.md
+++ b/doc/VSSDK012.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/VSSDK012.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/VSSDK012.html).

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,1 +1,1 @@
-This content has been moved to [GitHub Pages](https://microsoft.github.io/vssdk-analyzers/analyzers/index.html).
+This content has been moved to [GitHub Pages](https://microsoft.github.io/VSSDK-Analyzers/analyzers/index.html).

--- a/docfx/analyzers/VSSDK010.md
+++ b/docfx/analyzers/VSSDK010.md
@@ -1,11 +1,11 @@
 # VSSDK010 Remove unnecessary `ProvideAutoLoad` attribute
 
 Automatically loading a package has a performance cost. A package that only registers services, code expansions,
-or other declarative contributions does not need to load unless it overrides `Package.Initialize` or
-`AsyncPackage.InitializeAsync`.
+or other declarative contributions does not need to load unless it overrides `Package.Initialize`,
+`AsyncPackage.InitializeAsync`, or `AsyncPackage.OnAfterPackageLoadedAsync`.
 
 This analyzer reports each `ProvideAutoLoad` attribute on a package when neither the package nor an intermediate
-base class overrides the applicable initialization method.
+base class overrides an applicable initialization method.
 
 ## Example of a pattern that is flagged by this analyzer
 
@@ -34,4 +34,5 @@ class MyPackage : AsyncPackage
 ```
 
 If the package needs to run initialization code, override `Initialize` or `InitializeAsync` as appropriate instead
-of removing `ProvideAutoLoad`.
+of removing `ProvideAutoLoad`. An `AsyncPackage` may also override `OnAfterPackageLoadedAsync` for operations with
+side effects that should run soon after package loading rather than as a strict part of initialization.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/README.md
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/README.md
@@ -2,4 +2,4 @@
 
 This project is meant to provide a set of Roslyn Analyzers and automated code fixes that makes it easy to catch, discover and implement a wide array of best practices when building Visual Studio extensions.
 
-Check out our [exhaustive list of analyzers](https://microsoft.github.io/vssdk-analyzers/analyzers/index.html) defined in this project.
+Check out our [exhaustive list of analyzers](https://microsoft.github.io/VSSDK-Analyzers/analyzers/index.html) defined in this project.

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/Types.cs
@@ -203,6 +203,11 @@ namespace Microsoft.VisualStudio.SDK.Analyzers
             internal const string InitializeAsync = "InitializeAsync";
 
             /// <summary>
+            /// The name of the OnAfterPackageLoadedAsync method.
+            /// </summary>
+            internal const string OnAfterPackageLoadedAsync = "OnAfterPackageLoadedAsync";
+
+            /// <summary>
             /// The name of the GetServiceAsync method.
             /// </summary>
             internal const string GetServiceAsync = "GetServiceAsync";

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer.cs
@@ -67,8 +67,7 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
                 asyncPackageType is not null &&
                 provideAutoLoadAttributeType is not null &&
                 initializeMethod is not null &&
-                initializeAsyncMethod is not null &&
-                onAfterPackageLoadedAsyncMethod is not null)
+                initializeAsyncMethod is not null)
             {
                 start.RegisterSymbolAction(
                     Utils.DebuggableWrapper(symbolContext => AnalyzeNamedType(
@@ -91,7 +90,7 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
         INamedTypeSymbol provideAutoLoadAttributeType,
         IMethodSymbol initializeMethod,
         IMethodSymbol initializeAsyncMethod,
-        IMethodSymbol onAfterPackageLoadedAsyncMethod)
+        IMethodSymbol? onAfterPackageLoadedAsyncMethod)
     {
         var type = (INamedTypeSymbol)context.Symbol;
         if (type.TypeKind != TypeKind.Class || type.IsAbstract || !Utils.IsDerivedFrom(type, packageType))
@@ -118,7 +117,9 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
         }
 
         if (OverridesMethod(type, methodToOverride) ||
-            (Utils.IsEqualToOrDerivedFrom(type, asyncPackageType) && OverridesMethod(type, onAfterPackageLoadedAsyncMethod)))
+            (Utils.IsEqualToOrDerivedFrom(type, asyncPackageType) &&
+                onAfterPackageLoadedAsyncMethod is not null &&
+                OverridesMethod(type, onAfterPackageLoadedAsyncMethod)))
         {
             return;
         }

--- a/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer.cs
+++ b/src/Microsoft.VisualStudio.SDK.Analyzers/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer.cs
@@ -59,12 +59,16 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
             IMethodSymbol? initializeAsyncMethod = asyncPackageType?.GetMembers(Types.AsyncPackage.InitializeAsync)
                 .OfType<IMethodSymbol>()
                 .FirstOrDefault(method => method.Parameters.Length == 2);
+            IMethodSymbol? onAfterPackageLoadedAsyncMethod = asyncPackageType?.GetMembers(Types.AsyncPackage.OnAfterPackageLoadedAsync)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(method => method.Parameters.Length == 1);
 
             if (packageType is not null &&
                 asyncPackageType is not null &&
                 provideAutoLoadAttributeType is not null &&
                 initializeMethod is not null &&
-                initializeAsyncMethod is not null)
+                initializeAsyncMethod is not null &&
+                onAfterPackageLoadedAsyncMethod is not null)
             {
                 start.RegisterSymbolAction(
                     Utils.DebuggableWrapper(symbolContext => AnalyzeNamedType(
@@ -73,7 +77,8 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
                         asyncPackageType,
                         provideAutoLoadAttributeType,
                         initializeMethod,
-                        initializeAsyncMethod)),
+                        initializeAsyncMethod,
+                        onAfterPackageLoadedAsyncMethod)),
                     SymbolKind.NamedType);
             }
         });
@@ -85,7 +90,8 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
         INamedTypeSymbol asyncPackageType,
         INamedTypeSymbol provideAutoLoadAttributeType,
         IMethodSymbol initializeMethod,
-        IMethodSymbol initializeAsyncMethod)
+        IMethodSymbol initializeAsyncMethod,
+        IMethodSymbol onAfterPackageLoadedAsyncMethod)
     {
         var type = (INamedTypeSymbol)context.Symbol;
         if (type.TypeKind != TypeKind.Class || type.IsAbstract || !Utils.IsDerivedFrom(type, packageType))
@@ -111,7 +117,8 @@ public class VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzer : Diagnos
             methodToOverride = initializeMethod;
         }
 
-        if (OverridesMethod(type, methodToOverride))
+        if (OverridesMethod(type, methodToOverride) ||
+            (Utils.IsEqualToOrDerivedFrom(type, asyncPackageType) && OverridesMethod(type, onAfterPackageLoadedAsyncMethod)))
         {
             return;
         }

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests.cs
@@ -40,6 +40,58 @@ class Test : AsyncPackage
     }
 
     [Fact]
+    public async Task OlderAsyncPackageWithoutOnAfterPackageLoadedAsyncProducesDiagnosticAsync()
+    {
+        var testCode = /* lang=c#-test */ @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Shell
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class ProvideAutoLoadAttribute : Attribute
+    {
+        public ProvideAutoLoadAttribute(string uiContextGuid)
+        {
+        }
+    }
+
+    public class Package
+    {
+        protected virtual void Initialize()
+        {
+        }
+    }
+
+    public class AsyncPackage : Package
+    {
+        protected virtual Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public class ServiceProgressData
+    {
+    }
+}
+
+[{|#0:Microsoft.VisualStudio.Shell.ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"")|}]
+class Test : Microsoft.VisualStudio.Shell.AsyncPackage
+{
+}
+";
+
+        var test = new Verify.Test(includeVisualStudioSdk: false)
+        {
+            TestCode = testCode,
+        };
+        test.ExpectedDiagnostics.Add(Verify.Diagnostic().WithLocation(0).WithArguments("InitializeAsync"));
+        await test.RunAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task MultipleProvideAutoLoadAttributesProduceMultipleDiagnosticsAsync()
     {
         var test = /* lang=c#-test */ @"

--- a/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests.cs
+++ b/test/Microsoft.VisualStudio.SDK.Analyzers.Tests/VSSDK010RemoveUnnecessaryProvideAutoLoadAttributeAnalyzerTests.cs
@@ -100,6 +100,27 @@ class Test : AsyncPackage
     }
 
     [Fact]
+    public async Task AsyncPackageWithOnAfterPackageLoadedAsyncOverrideProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
+class Test : AsyncPackage
+{
+    protected override Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)
+    {
+        return base.OnAfterPackageLoadedAsync(cancellationToken);
+    }
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task InheritedInitializeAsyncOverrideProducesNoDiagnosticAsync()
     {
         var test = /* lang=c#-test */ @"
@@ -113,6 +134,31 @@ abstract class BasePackage : AsyncPackage
     protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
         return base.InitializeAsync(cancellationToken, progress);
+    }
+}
+
+[ProvideAutoLoad(""{F184B08F-C81C-45F6-A57F-5ABD9991F28F}"", PackageAutoLoadFlags.BackgroundLoad)]
+class Test : BasePackage
+{
+}
+";
+
+        await Verify.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task InheritedOnAfterPackageLoadedAsyncOverrideProducesNoDiagnosticAsync()
+    {
+        var test = /* lang=c#-test */ @"
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+
+abstract class BasePackage : AsyncPackage
+{
+    protected override Task OnAfterPackageLoadedAsync(CancellationToken cancellationToken)
+    {
+        return base.OnAfterPackageLoadedAsync(cancellationToken);
     }
 }
 


### PR DESCRIPTION
VSSDK010 currently reports `ProvideAutoLoad` as unnecessary when an `AsyncPackage` uses `OnAfterPackageLoadedAsync` for post-load side effects instead of `InitializeAsync`.

Treat direct and inherited `OnAfterPackageLoadedAsync` overrides as valid reasons for automatic package loading. Add analyzer coverage for both cases and document all three accepted lifecycle methods.

Tests: Focused VSSDK010 analyzer test class passes.